### PR TITLE
KB-6563 | DEV| Assessment | BE | Consumption Logic for the CQF Assessment

### DIFF
--- a/src/main/java/org/sunbird/cqfassessment/service/CQFAssessmentServiceImpl.java
+++ b/src/main/java/org/sunbird/cqfassessment/service/CQFAssessmentServiceImpl.java
@@ -510,11 +510,6 @@ public class CQFAssessmentServiceImpl implements CQFAssessmentService {
 
         Map<String, Object> assessmentData = readAssessmentLevelData(assessmentAllDetail);
         response.getResult().put(Constants.QUESTION_SET, assessmentData);
-
-        if (Boolean.FALSE.equals(updateAssessmentDataToDB(cqfAssessmentModel, assessmentData))) {
-            updateErrorDetails(response, Constants.ASSESSMENT_DATA_START_TIME_NOT_UPDATED);
-        }
-
         return response;
     }
 


### PR DESCRIPTION

1. If the user submits the cqf assessment the status was changed to submitted but if he did the assessment read the status was getting changed to not-submitted.