### PR TITLE
KB-7426 | DEV | BE | Self Registration | Wrapper API to update the orgname and other details.

### DIFF
--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1294,6 +1294,7 @@ public class Constants {
 	public static final String JPG="jpg";
 	public static final String REGISTRATION_START_DATE = "registrationStartDate";
 	public static final String LOGO = "logo";
+	public static final String API_ORG_EXT_UPDATE = "api.org.extended.update";
 
 	private Constants() {
 		throw new IllegalStateException("Utility class");

--- a/src/main/java/org/sunbird/org/controller/ExtendedOrgController.java
+++ b/src/main/java/org/sunbird/org/controller/ExtendedOrgController.java
@@ -5,12 +5,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.sunbird.common.model.SBApiResponse;
 import org.sunbird.common.util.Constants;
 import org.sunbird.org.service.ExtendedOrgService;
@@ -25,6 +20,13 @@ public class ExtendedOrgController {
 	public ResponseEntity<SBApiResponse> createOrg(@RequestBody Map<String, Object> orgRequest,
 			@RequestHeader(Constants.X_AUTH_TOKEN) String userToken) throws Exception {
 		SBApiResponse response = orgService.createOrg(orgRequest, userToken);
+		return new ResponseEntity<>(response, response.getResponseCode());
+	}
+
+	@PatchMapping("/org/ext/v1/update")
+	public ResponseEntity<SBApiResponse> updateOrg(@RequestBody Map<String, Object> orgRequest,
+												   @RequestHeader(Constants.X_AUTH_TOKEN) String userToken) {
+		SBApiResponse response = orgService.update(orgRequest, userToken);
 		return new ResponseEntity<>(response, response.getResponseCode());
 	}
 

--- a/src/main/java/org/sunbird/org/repository/OrgHierarchyRepository.java
+++ b/src/main/java/org/sunbird/org/repository/OrgHierarchyRepository.java
@@ -62,4 +62,10 @@ public interface OrgHierarchyRepository extends JpaRepository<OrgHierarchy, Inte
 
     @Query(value = "SELECT * FROM org_hierarchy_v4 WHERE LOWER(?1) IN (LOWER(parentmapid), LOWER(l1MapId), LOWER(l2MapId), LOWER(l3MapId))  AND sborgid IS NOT NULL", nativeQuery = true)
     List<OrgHierarchy> findAllOrgByParentMapId(String parentMapId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE org_hierarchy_v4 SET orgname = ?2 WHERE sborgid = ?1", nativeQuery = true)
+    void updateOrgNameBySbOrgId(String sbOrgId, String orgName);
+
 }

--- a/src/main/java/org/sunbird/org/service/ExtendedOrgService.java
+++ b/src/main/java/org/sunbird/org/service/ExtendedOrgService.java
@@ -19,4 +19,6 @@ public interface ExtendedOrgService {
 	public SBApiResponse orgExtSearchV2(Map<String, Object> request);
 
 	SBApiResponse listAllOrg(String parentMapId);
+
+	SBApiResponse update(Map<String, Object> orgRequest, String userToken);
 }

--- a/src/main/java/org/sunbird/org/service/ExtendedOrgServiceImpl.java
+++ b/src/main/java/org/sunbird/org/service/ExtendedOrgServiceImpl.java
@@ -26,7 +26,6 @@ import org.sunbird.common.service.OutboundRequestHandlerServiceImpl;
 import org.sunbird.common.util.CbExtServerProperties;
 import org.sunbird.common.util.Constants;
 import org.sunbird.common.util.ProjectUtil;
-import org.sunbird.core.logger.CbExtLogger;
 import org.sunbird.org.model.OrgHierarchy;
 import org.sunbird.org.model.OrgHierarchyInfo;
 import org.sunbird.org.repository.OrgHierarchyRepository;
@@ -838,5 +837,124 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 		}
 
 		return response;
+	}
+
+	/**
+	 * Updates the organization details for the given organization ID.
+	 *
+	 * @param orgRequest the organization request data
+	 * @param userToken  the user authentication token
+	 * @return the API response object
+	 */
+	@Override
+	public SBApiResponse update(Map<String, Object> orgRequest, String userToken) {
+		logger.info("ExtendedOrgServiceImpl::update::Starting the update of the organization");
+		SBApiResponse outgoingResponse = ProjectUtil.createDefaultResponse(Constants.API_ORG_EXT_UPDATE);
+		String errMsg = validateRequestFields(orgRequest, outgoingResponse);
+		if (!StringUtils.isEmpty(errMsg)) return outgoingResponse;
+		List<OrgHierarchy> orgHierarchyList = orgRepository.findAllBySbOrgId(Collections.singletonList((String) orgRequest.get(Constants.ORG_ID)));
+		String sborgsubtype = "";
+		if (CollectionUtils.isNotEmpty(orgHierarchyList) && orgHierarchyList.get(0) != null) {
+			sborgsubtype = orgHierarchyList.get(0).getSbOrgSubType();
+			logger.info("ExtendedOrgServiceImpl::update::SbOrgType: " + sborgsubtype + " for the organization" + orgRequest.get(Constants.ORG_ID));
+		}
+		if (Constants.BOARD.equalsIgnoreCase(sborgsubtype)) {
+			logger.info("ExtendedOrgServiceImpl::update:: Updating the board details for organization:" + orgRequest.get(Constants.ORG_ID));
+			orgRepository.updateOrgNameBySbOrgId((String) orgRequest.get(Constants.ORG_ID), (String) orgRequest.get(Constants.ORG_NAME));
+			OrgHierarchyInfo orgHierarchyInfo = new OrgHierarchyInfo();
+			orgHierarchyInfo.setOrgName((String) orgRequest.get(Constants.ORG_NAME));
+			orgHierarchyInfo.setSbOrgId((String) orgRequest.get(Constants.ORG_ID));
+			Map<String, Object> orgDataUpdateResonse = updateOrgDetailsToDB(userToken, orgHierarchyInfo, orgRequest);
+			if (MapUtils.isEmpty(orgDataUpdateResonse) || !orgDataUpdateResonse.get(Constants.RESPONSE_CODE).equals(Constants.OK)) {
+				logger.info("ExtendedOrgServiceImpl::update::Failed to update Org details for organization: " + orgHierarchyInfo.getSbOrgId());
+				setInternalServerError(outgoingResponse, "Error while updating the organization details");
+			} else {
+				populateSuccessResponse(outgoingResponse);
+			}
+		} else {
+			Map<String, Object> result = new HashMap<>();
+			logger.info("ExtendedOrgServiceImpl::update:: SbOrgType is not 'board' for the organization:" + orgRequest.get(Constants.ORG_ID));
+			result.put(Constants.SB_SUB_ORG_TYPE, "Updating ministry,state or department is not allowed");
+			outgoingResponse.getResult().putAll(result);
+			outgoingResponse.getParams().setStatus(Constants.OK);
+			outgoingResponse.setResponseCode(HttpStatus.OK);
+		}
+		return outgoingResponse;
+	}
+
+	/**
+	 * Validates specific fields in the request and updates the API response accordingly.
+	 *
+	 * @param request  The request object.
+	 * @param response The API response object.
+	 * @return An error message if any required field is invalid, otherwise an empty string.
+	 */
+	private String validateRequestFields(Map<String, Object> request, SBApiResponse response) {
+		if (StringUtils.isBlank(MapUtils.getString(request, Constants.ORG_ID))) {
+			response.getParams().setStatus(Constants.FAILED);
+			response.getParams().setErrmsg("Organization ID is missing");
+			response.setResponseCode(HttpStatus.BAD_REQUEST);
+			return "Organization ID is missing";
+		}
+		if (StringUtils.isBlank(MapUtils.getString(request, Constants.ORG_NAME))) {
+			response.getParams().setStatus(Constants.FAILED);
+			response.getParams().setErrmsg("Organization name is missing");
+			response.setResponseCode(HttpStatus.BAD_REQUEST);
+			return "Organization name is missing";
+		}
+		return "";
+	}
+
+
+	/**
+	 * Updates the organization details in the database using the provided request data.
+	 *
+	 * @param authUserToken    the authentication token for the user making the request
+	 * @param orgHierarchyInfo the organization hierarchy information
+	 * @param orgRequest       the organization request data
+	 * @return the result of the update operation
+	 */
+	private Map<String, Object> updateOrgDetailsToDB(String authUserToken, OrgHierarchyInfo orgHierarchyInfo, Map<String, Object> orgRequest) {
+		logger.info("ExtendedOrgServiceImpl::updateOrgDetailsToDB:Updating the Org details for the organization." + orgHierarchyInfo.getSbOrgId());
+		Map<String, Object> request = new HashMap<>();
+		Map<String, Object> updateRequest = new HashMap<>();
+		Map<String, String> headerValues = new HashMap<>();
+		headerValues.put(Constants.X_AUTH_TOKEN, authUserToken);
+		request.put(Constants.ORGANIZATION_ID, orgHierarchyInfo.getSbOrgId());
+		request.put(Constants.ORG_NAME, orgHierarchyInfo.getOrgName());
+		if (MapUtils.getObject(orgRequest, Constants.DESCRIPTION) != null) {
+			request.put(Constants.DESCRIPTION, orgRequest.get(Constants.DESCRIPTION));
+		}
+		if (MapUtils.getObject(orgRequest, Constants.LOGO) != null) {
+			request.put(Constants.LOGO, orgRequest.get(Constants.LOGO));
+		}
+		updateRequest.put(Constants.REQUEST, request);
+		return outboundService.fetchResultUsingPatch(
+				configProperties.getSbUrl() + configProperties.getUpdateOrgPath(), updateRequest, headerValues);
+	}
+
+	/**
+	 * Sets the internal server error response for a given API response object.
+	 *
+	 * @param response the API response object to update
+	 * @param errorMsg the error message to include in the response
+	 */
+	private void setInternalServerError(SBApiResponse response, String errorMsg) {
+		response.getParams().setStatus(HttpStatus.INTERNAL_SERVER_ERROR.toString());
+		response.getParams().setErrmsg(errorMsg);
+		response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	/**
+	 * Populates the success response object with the result of the organization ID update operation.
+	 *
+	 * @param response the API response object to be populated
+	 */
+	private void populateSuccessResponse(SBApiResponse response) {
+		Map<String, Object> result = new HashMap<>();
+		result.put(Constants.ORGANIZATION_ID, "Organisation Id Updated successfully");
+		response.getResult().putAll(result);
+		response.getParams().setStatus(Constants.OK);
+		response.setResponseCode(HttpStatus.OK);
 	}
 }

--- a/src/main/java/org/sunbird/user/registration/service/UserRegistrationServiceImpl.java
+++ b/src/main/java/org/sunbird/user/registration/service/UserRegistrationServiceImpl.java
@@ -165,10 +165,10 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
 		properyMap.put(Constants.ID, userRegInfo.getSbOrgId());
 		List<Map<String, Object>> cassandraResponse = cassandraOperation.getRecordsByPropertiesWithoutFiltering(Constants.KEYSPACE_SUNBIRD,
 				Constants.TABLE_ORGANIZATION, properyMap, null);
-		String registrationstartdate = (String) cassandraResponse.get(0).get("registrationStartDate");
-		String registrationenddate = (String) cassandraResponse.get(0).get("registrationEndDate");
+		String registrationstartdate = (String) cassandraResponse.get(0).get("startdateregistration");
+		String registrationenddate = (String) cassandraResponse.get(0).get("enddateregistration");
 		if (StringUtils.isNotEmpty(registrationstartdate) && StringUtils.isNotEmpty(registrationenddate) ) {
-			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // Adjust format if necessary
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"); // Adjust format if necessary
 			ZonedDateTime registrationStartDate = ZonedDateTime.parse(registrationstartdate, formatter.withZone(ZoneId.of("Asia/Calcutta")));
 			ZonedDateTime registrationEndDate = ZonedDateTime.parse(registrationstartdate, formatter.withZone(ZoneId.of("Asia/Calcutta")));
 			ZonedDateTime currentDateTime = ZonedDateTime.now(ZoneId.of("Asia/Calcutta"));


### PR DESCRIPTION
1. Added new API org update .
2. It fetches the data from postgres by passing sborgid and checks if the sborgsubtype is board if it is then allows to update the orgname.
3. The orgname update is only applicable for organisation , its not allowed for the ministry,state and department.
4. Once the data is updated we call the learner service orgupdate to update the data in cassandra and sync back data to elastic search.
5. Apart from updating orgname we can update the logo and description field if its available in the request body else it is skipped.
6. Changed the attribute name in the self registration api and the date format also - changed wrt KB-7399
