### PR TITLE
KB-7427 | DEV | BE | Self Registration | Creating new entity for persisting the QR data and other meta.

### DIFF
--- a/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
+++ b/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
@@ -963,6 +963,9 @@ public class CbExtServerProperties {
 	@Value("${bp.report.default.field.map}")
 	private String bpEnrolmentReportDefaultFields;
 
+	@Value("${qr.custom.self.registration.skip.validation}")
+	private String skipQRCodeValdationCheck;
+
 	public String getCiosCloudIconFolderName() {
 		return ciosCloudIconFolderName;
 	}
@@ -3326,5 +3329,13 @@ public class CbExtServerProperties {
 
 	public void setBpEnrolmentReportDefaultFields(String bpEnrolmentReportDefaultFields) {
 		this.bpEnrolmentReportDefaultFields = bpEnrolmentReportDefaultFields;
+	}
+
+	public String getSkipQRCodeValdationCheck() {
+		return skipQRCodeValdationCheck;
+	}
+
+	public void setSkipQRCodeValdationCheck(String skipQRCodeValdationCheck) {
+		this.skipQRCodeValdationCheck = skipQRCodeValdationCheck;
 	}
 }

--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1295,6 +1295,11 @@ public class Constants {
 	public static final String REGISTRATION_START_DATE = "registrationStartDate";
 	public static final String LOGO = "logo";
 	public static final String API_ORG_EXT_UPDATE = "api.org.extended.update";
+	public static final String CREATED_DATE_TIME = "createdDateTime";
+	public static final String NUMBER_OF_USERS_ONBOARDED = "numberOfUsersOnBoarded";
+	public static final String REGISTRATION_QR_CODE_TABLE = "registration_qr_code";
+	public static final String EXPIRED = "expired";
+	public static final String TRUE = "true";
 
 	private Constants() {
 		throw new IllegalStateException("Utility class");

--- a/src/main/java/org/sunbird/customselfregistration/model/CustomSelfRegistrationModel.java
+++ b/src/main/java/org/sunbird/customselfregistration/model/CustomSelfRegistrationModel.java
@@ -11,11 +11,16 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class CustomSelfRegistrationModel {
-    Long registrationstartdate;
-    Long registrationenddate;
+    String registrationstartdate;
+    String registrationenddate;
     String logo;
     String description;
     String orgId;
     String registrationLink;
     String qrCodeFilePath;
+    String id;
+    String status;
+    String createdby;
+    String createddatetime;
+    Long numberofusersonboarded;
 }

--- a/src/main/java/org/sunbird/user/registration/service/UserRegistrationServiceImpl.java
+++ b/src/main/java/org/sunbird/user/registration/service/UserRegistrationServiceImpl.java
@@ -106,12 +106,6 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
 
 					if (regDocument == null
 							|| UserRegistrationStatus.FAILED.name().equalsIgnoreCase(regDocument.getStatus())) {
-						String errorMsg=validateRegistrationDates(userRegInfo);
-						if (StringUtils.isNotBlank(errorMsg)) {
-							response.setResponseCode(HttpStatus.OK);
-							response.getResult().put(Constants.RESULT, errorMsg);
-							return response;
-						}
 						// create / update the doc in ES
 						RestStatus status = null;
 						if (regDocument == null) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -513,6 +513,7 @@ url.custom.self.registration: https://portal.dev.karmayogibharat.net/crp?id=
 qr.custom.self.registration.upload.container.name: igot
 qr.custom.self.registration.upload.folder.name: customselfregistration-qrcodes
 qr.custom.self.registration.upload.path:  https://portal.dev.karmayogibharat.net/content-store/customselfregistration-qrcodes
+qr.custom.self.registration.skip.validation: false
 
 #PublicUserEventBulkonboard
 public.user.event.bulk.onboard.topic=dev.public.user.event.bulk.onboard


### PR DESCRIPTION
1. Created a new entity registration_qr_code which persists the qr data and other meta data.
2. We check if there is a active qrcode link if its active then we will restrict to generate new qr.
3. One new configuration is there which allows to generate new qr code even if there is a active qr code - by default its set to false .
4. Removed the registration date updates to the organisation table- this update was done using learner service.
