### PR TITLE
KB-7482 | DEV | BE | Self Registration | Enhancements of logo upload while organisation creation and adding other attributes to the orgtable.

### DIFF
--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1305,6 +1305,9 @@ public class Constants {
 	public static final String IMAGE_UPLOAD_GCP_CONTAINER = "api.image.upload.togcp.container";
 	public static final String CLOUD_FOLDER_NAME = "cloudFolderName";
 	public static final String CLOUD_CONTAINER_NAME = "containerName";
+	public static final String MINISTRY_STATE_NAME = "ministryOrStateName";
+	public static final String MINISTRY_STATE_TYPE = "ministryOrStateType";
+
 	private Constants() {
 		throw new IllegalStateException("Utility class");
 	}


### PR DESCRIPTION
1. Validation of the parentMapId while creating the organisation.
2. We Validate the parentMapId only for the organisationsubtype as board.
3. We fetch the deptDetails based on the parentMapid ie. by passing the mapid data with parentmapid and similiarily the ministry details and state details and construct the request body.
4. After constructing the request body the request goes to the learner service for the organistation creation
