### PR TITLE
KB-7427 | DEV | BE | Self Registration | Creating new entity for persisting the QR data and other meta.

### DIFF
--- a/src/main/java/org/sunbird/org/repository/CustomSelfRegistrationRepository.java
+++ b/src/main/java/org/sunbird/org/repository/CustomSelfRegistrationRepository.java
@@ -23,4 +23,9 @@ public interface CustomSelfRegistrationRepository extends JpaRepository<CustomeS
 
     @Query(value = "SELECT * from registration_qr_code where orgid=?1 and id=?2", nativeQuery = true)
     CustomeSelfRegistrationEntity findAllByOrgIdAndUniqueId(String orgId,String uniqueId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE registration_qr_code SET numberofusersonboarded = ?3 WHERE orgid = ?1 AND id = ?2", nativeQuery = true)
+    void updateRegistrationQrCodeOnboardUserCount(String orgId, String uniqueId, long status);
 }

--- a/src/main/java/org/sunbird/org/service/ExtendedOrgServiceImpl.java
+++ b/src/main/java/org/sunbird/org/service/ExtendedOrgServiceImpl.java
@@ -971,7 +971,7 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 	private String validateRequestFieldsOrganisationCreate(Map<String, Object> request, SBApiResponse response) {
 		if (StringUtils.isBlank(MapUtils.getString(request, Constants.PARENT_MAP_ID)) && Constants.BOARD.equalsIgnoreCase(MapUtils.getString(request, Constants.ORGANIZATION_SUB_TYPE))) {
 			response.getParams().setStatus(Constants.FAILED);
-			response.getParams().setErrmsg("Parent Map ID is missing");
+			response.getParams().setErrmsg("Parent Map ID is Empty/missing");
 			response.setResponseCode(HttpStatus.BAD_REQUEST);
 			return "Parent Map ID is missing";
 		}
@@ -988,7 +988,7 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 		if (Constants.BOARD.equalsIgnoreCase((String) request.get(Constants.ORGANIZATION_SUB_TYPE))) {
 			logger.info("ExtendedOrgServiceImpl::fetchStateOrMinistryDetails:Fetching the state or ministry details based on the parent map ID." + request.get("parentMapId"));
 			OrgHierarchy deptOrgDetails = orgRepository.findByMapId((String) request.get(Constants.PARENT_MAP_ID));
-			if (StringUtils.isNotEmpty(deptOrgDetails.getOrgName())) {
+			if (StringUtils.isNotEmpty(deptOrgDetails.getOrgName()) && "department".equalsIgnoreCase(deptOrgDetails.getSbOrgSubType())) {
 				logger.info("ExtendedOrgServiceImpl::fetchStateOrMinistryDetails: Found department details. " +
 						"DeptName: {}, ParentMapId: {}", deptOrgDetails.getOrgName(), deptOrgDetails.getParentMapId());
 				request.put(Constants.DEPT_NAME, deptOrgDetails.getOrgName());
@@ -1001,6 +1001,10 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 					request.put(Constants.MINISTRY_STATE_NAME, ministryOrgDetails.getOrgName());
 					request.put(Constants.MINISTRY_STATE_TYPE, ministryOrgDetails.getSbOrgType());
 				}
+			} else if (StringUtils.isNotEmpty(deptOrgDetails.getOrgName()) &&
+					(Constants.MINISTRY.equalsIgnoreCase(deptOrgDetails.getSbOrgType()) || Constants.STATE.equalsIgnoreCase(deptOrgDetails.getSbOrgType()))) {
+				request.put(Constants.MINISTRY_STATE_NAME, deptOrgDetails.getOrgName());
+				request.put(Constants.MINISTRY_STATE_TYPE, deptOrgDetails.getSbOrgType());
 			}
 		}
 	}

--- a/src/main/java/org/sunbird/user/registration/model/UserRegistrationInfo.java
+++ b/src/main/java/org/sunbird/user/registration/model/UserRegistrationInfo.java
@@ -40,7 +40,7 @@ public class UserRegistrationInfo {
     private String category;
     private String pincode;
     private List<String> roles;
-    private String uniqueCodeRegistration;
+    private String registrationLink;
 
     public String getRegistrationCode() {
         return registrationCode;
@@ -242,11 +242,11 @@ public class UserRegistrationInfo {
         this.roles = roles;
     }
 
-    public String getUniqueCodeRegistration() {
-        return uniqueCodeRegistration;
+    public String getRegistrationLink() {
+        return registrationLink;
     }
 
-    public void setUniqueCodeRegistration(String uniqueCodeRegistration) {
-        this.uniqueCodeRegistration = uniqueCodeRegistration;
+    public void setRegistrationLink(String registrationLink) {
+        this.registrationLink = registrationLink;
     }
 }

--- a/src/main/java/org/sunbird/user/registration/service/UserRegistrationServiceImpl.java
+++ b/src/main/java/org/sunbird/user/registration/service/UserRegistrationServiceImpl.java
@@ -112,6 +112,14 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
 
 					if (regDocument == null
 							|| UserRegistrationStatus.FAILED.name().equalsIgnoreCase(regDocument.getStatus())) {
+						if(StringUtils.isNotEmpty(userRegInfo.getRegistrationLink())) {
+							String errorMsg = validateRegistrationDates(userRegInfo);
+							if (StringUtils.isNotBlank(errorMsg)) {
+								response.setResponseCode(HttpStatus.OK);
+								response.getResult().put(Constants.RESULT, errorMsg);
+								return response;
+							}
+						}
 						// create / update the doc in ES
 						RestStatus status = null;
 						if (regDocument == null) {
@@ -658,7 +666,7 @@ public class UserRegistrationServiceImpl implements UserRegistrationService {
 	private String validateRegistrationDates(UserRegistrationInfo userRegistrationInfo) {
 		LOGGER.info("UserRegistrationServiceImpl::validateRegistrationDates : started");
 		String orgId = userRegistrationInfo.getSbOrgId();
-		String uniqueCode = userRegistrationInfo.getUniqueCodeRegistration();
+		String uniqueCode = extractIdFromUrl(userRegistrationInfo.getRegistrationLink());
 		if (StringUtils.isEmpty(uniqueCode)) {
 			LOGGER.info("UserRegistrationServiceImpl::validateRegistrationDates : uniqueCode is missing for orgId " + orgId);
 			return "";


### PR DESCRIPTION
1.While generating the qr code we save the registration metadata to the new table in the postres i.e registration_qr_code.
2. Added new method to update the count of the onboarded user based on the org and the unique code.
3.Checking If the org is created under ministry/state or department and fetching the details accordingly.
4. Renamed the attribute uniqueCodeRegistration to registrationLink.
5. Updating the user count in the consumer topic of the user registration.
6. Validation of the user on the registration api.
