### PR TITLE
Validating user bulk upload INITIATED status instead of IN-PROGRESS

### DIFF
--- a/src/main/java/org/sunbird/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/org/sunbird/profile/service/ProfileServiceImpl.java
@@ -2346,7 +2346,7 @@ public class ProfileServiceImpl implements ProfileService {
 			return false;
 		}
 		return bulkUploadMdoList.stream()
-				.anyMatch(entry -> Constants.STATUS_IN_PROGRESS_UPPERCASE.equalsIgnoreCase((String) entry.get(Constants.STATUS)));
+				.anyMatch(entry -> Constants.INITIATED_CAPITAL.equalsIgnoreCase((String) entry.get(Constants.STATUS)));
 	}
 
 	private void setErrorDataForMdo(SBApiResponse response, String errMsg) {

--- a/src/main/java/org/sunbird/profile/service/UserBulkUploadService.java
+++ b/src/main/java/org/sunbird/profile/service/UserBulkUploadService.java
@@ -501,6 +501,8 @@ public class UserBulkUploadService {
                     headers.add("Error Details");
                 }
 
+                Set<String> processedEmailSet = new HashSet<>();
+                Set<String> processedPhoneSet = new HashSet<>();
                 for (CSVRecord record : csvRecords) {
                     Map<String, String> updatedRecord = new LinkedHashMap<>(record.toMap());
                     try {
@@ -535,8 +537,13 @@ public class UserBulkUploadService {
                         if (isFieldEmpty(record, 1)) {
                             errList.add("Email");
                         } else {
-                            String email = record.get(1).trim();
-                            userRegistration.setEmail(email);
+                            String email = record.get(1).trim().toLowerCase();
+                            // Check if this email has already been processed
+                            if (!processedEmailSet.add(email)) {
+                                errList.add("Duplicate email found.");
+                            } else {
+                                userRegistration.setEmail(email);
+                            }
                         }
 
                         if (isFieldEmpty(record, 2)) {
@@ -544,7 +551,12 @@ public class UserBulkUploadService {
                         } else {
                             String phone = record.get(2).trim();
                             if (phone.matches("^\\d+$")) {
-                                userRegistration.setPhone(phone);
+                                // Check if this phone has already been processed
+                                if (!processedPhoneSet.add(phone)) {
+                                    errList.add("Duplicate mobile found.");
+                                } else {
+                                    userRegistration.setPhone(phone);
+                                }
                             } else {
                                 invalidErrList.add("Invalid value for Mobile Number column type. Expecting number format");
                             }
@@ -703,6 +715,8 @@ public class UserBulkUploadService {
                     updatedRecords.add(updatedRecord);
                 }
                 logger.info("total noOfSuccessfulRecords {}, total noOfFailedRecordsCount {}, and total totalRecordsCount {}", noOfSuccessfulRecords,failedRecordsCount,totalRecordsCount);
+                processedEmailSet.clear();
+                processedPhoneSet.clear();
                 // Write back updated records to the same CSV file
                 fileWriter = new FileWriter(file);
                 bufferedWriter = new BufferedWriter(fileWriter);


### PR DESCRIPTION
I have changed the status validation for the user’s bulk upload from IN-PROGRESS to INITIATED. The reason for this is that the status is set to INITIATED immediately after the file is uploaded to the server and an entry is made in Cassandra. We then change the status to IN-PROGRESS while processing the file on the consumer side. During this process, there can be a gap of seconds or even minutes if all the consumers are busy. If we validate the status as IN-PROGRESS, it could allow the same organisation to upload another file prematurely. By validating the INITIATED status, we can prevent additional uploads more promptly.