### PR TITLE
4.8.30 dev v1 (#534)

### DIFF
--- a/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
+++ b/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
@@ -1127,6 +1127,15 @@ public class CbExtServerProperties {
     @Value("${kafka.topics.org.user.bulk.transfer.event}")
     private String orgHierarchyUserBulkTransferTopic;
 
+    @Value("${bp.assignment.ans.folder.name}")
+    private String bpAssignmentAnsFolderName;
+
+    @Value("${bp.assignment.answer.file.upload.max-size-kb}")
+    private long bpAssignmentAnsFileMaxSize;
+
+    @Value("#{'${bp.assignment.answer.file.upload.allowed-extensions}'.split(',')}")
+    private List<String> bpAssignmentAnsFileExtensions;
+
     public String getStateLearningInsightsRedisKeyMapping() {
 		return stateLearningInsightsRedisKeyMapping;
 	}
@@ -3790,4 +3799,29 @@ public class CbExtServerProperties {
     public String getOrgHierarchyUserBulkTransferTopic() {
         return orgHierarchyUserBulkTransferTopic;
     }
+
+    public String getBpAssignmentAnsFolderName() {
+        return bpAssignmentAnsFolderName;
+    }
+
+    public void setBpAssignmentAnsFolderName(String bpAssignmentAnsFolderName) {
+        this.bpAssignmentAnsFolderName = bpAssignmentAnsFolderName;
+    }
+
+    public long getBpAssignmentAnsFileMaxSize() {
+        return bpAssignmentAnsFileMaxSize;
+    }
+
+    public void setBpAssignmentAnsFileMaxSize(long bpAssignmentAnsFileMaxSize) {
+        this.bpAssignmentAnsFileMaxSize = bpAssignmentAnsFileMaxSize;
+    }
+
+    public List<String> getBpAssignmentAnsFileExtensions() {
+        return bpAssignmentAnsFileExtensions;
+    }
+
+    public void setBpAssignmentAnsFileExtensions(List<String> bpAssignmentAnsFileExtensions) {
+        this.bpAssignmentAnsFileExtensions = bpAssignmentAnsFileExtensions;
+    }
+
 }

--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1435,6 +1435,17 @@ public class Constants {
     public static final String HEADER_ROW_NOT_FOUND = "Header row not found in Excel file";
     public static final String ORGANIZATION_MISMATCH = "User's current organization does not match with the root organization. Please verify the organization hierarchy.";
     public static final String EMPTY_FILE = "The uploaded file is empty or could not be processed";
+    public static final String ASSIGNMENT_UPLOAD_FILE = "api.blended_program.Assignment.ans.fileUpload";
+    public static final String FILE_EMPTY = "Uploaded file is empty.";
+    public static final String INVALID_CONTENT_ID = "Invalid or missing content ID.";
+    public static final String INVALID_BATCH_ID = "Invalid or missing batch ID.";
+    public static final String INVALID_FORM_ID = "Invalid or missing form ID.";
+    public static final String FILE = "file";
+    public static final String EMPTY_FILE_NAME = "The uploaded file name is empty or could not be processed";
+    public static final String FILE_NOT_FOUND = "File not found for the given details.";
+    public static final String READ_ASSIGNMENT_FILE = "api.assignment.answer.read";
+    public static final String READ_ASSIGNMENT_FILE_VALIDATION = "api.assignment.answer.read.validation";
+    public static final String UNAUTHORIZED_USER = "Unauthorized user or invalid token.";
     private Constants() {
 		throw new IllegalStateException("Utility class");
 	}

--- a/src/main/java/org/sunbird/common/util/ProjectUtil.java
+++ b/src/main/java/org/sunbird/common/util/ProjectUtil.java
@@ -260,4 +260,13 @@ public class ProjectUtil {
 		headers.put(Constants.X_AUTH_TOKEN, userAuthToken);
 		return headers;
 	}
+
+    public static SBApiResponse returnErrorMsg(String errMsg, HttpStatus httpStatus, SBApiResponse response, String status) {
+        response.getParams().setStatus(status);
+        response.getParams().setErrmsg(errMsg);
+        response.setResponseCode(httpStatus);
+        response.getResult().put("message", errMsg);
+        return response;
+    }
+
 }

--- a/src/main/java/org/sunbird/storage/controller/StorageController.java
+++ b/src/main/java/org/sunbird/storage/controller/StorageController.java
@@ -120,4 +120,26 @@ public class StorageController {
 		SBApiResponse uploadResponse = storageService.uploadImageToGCPContainer(multipartFile, requestBody,authUserToken);
 		return new ResponseEntity<>(uploadResponse, uploadResponse.getResponseCode());
 	}
+
+    @PostMapping("/v1/bp/assignment/answer/{contentId}/{batchId}/{formId}")
+    public ResponseEntity<SBApiResponse> uploadAssignmentFile(
+            @RequestParam(value = Constants.FILE, required = true) MultipartFile multipartFile,
+            @PathVariable(value = Constants.CONTENT_ID_KEY, required = true) String contentId,
+            @PathVariable(value = Constants.BATCH_ID, required = true) String batchId,
+            @PathVariable(value = Constants.FORM_ID, required = true) String formId) {
+        SBApiResponse uploadResponse = storageService.uploadAssignmentAnsFile(multipartFile, contentId, batchId, formId);
+        return new ResponseEntity<>(uploadResponse, uploadResponse.getResponseCode());
+    }
+
+    @GetMapping("/v1/bp/assignment/answer/read/file")
+    public ResponseEntity<?> readAssignmentAnswerFile(
+            @RequestParam(value = "contentId", required = true) String contentId,
+            @RequestParam(value = "batchId", required = true) String batchId,
+            @RequestParam(value = "formId", required = true) String formId,
+            @RequestParam(value = "fileName", required = true) String fileName,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String userToken){
+        return storageService.readAssignmentAnsFile(contentId, batchId, formId, fileName, userToken);
+    }
+
+
 }

--- a/src/main/java/org/sunbird/storage/service/StorageService.java
+++ b/src/main/java/org/sunbird/storage/service/StorageService.java
@@ -52,4 +52,9 @@ public interface StorageService {
 	 * @return the response object containing the result of the upload operation
 	 */
 	SBApiResponse uploadImageToGCPContainer(MultipartFile multipartFile, Map<String, Object> requestBody, String authUserToken);
+
+    SBApiResponse uploadAssignmentAnsFile(MultipartFile multipartFile, String contentId, String batchId, String formId);
+
+    ResponseEntity<?> readAssignmentAnsFile(String contentId, String batchId, String formId, String fileName, String userToken);
+
 }

--- a/src/main/java/org/sunbird/storage/service/StorageServiceImpl.java
+++ b/src/main/java/org/sunbird/storage/service/StorageServiceImpl.java
@@ -9,9 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import javax.annotation.PostConstruct;
 
@@ -672,4 +670,173 @@ public class StorageServiceImpl implements StorageService {
 		response.getParams().setErrmsg(Constants.USER_ID_DOESNT_EXIST);
 		response.setResponseCode(responseCode);
 	}
+
+    @Override
+    public SBApiResponse uploadAssignmentAnsFile(MultipartFile multipartFile, String contentId, String batchId, String formId) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.ASSIGNMENT_UPLOAD_FILE);
+
+        SBApiResponse validationError = validateAssignmentFileInputs(multipartFile, contentId, batchId, formId);
+        if (validationError != null) {
+            return validationError;
+        }
+        File tempFile = null;
+        try {
+            tempFile = new File(System.currentTimeMillis() + "_" + multipartFile.getOriginalFilename());
+            if (!tempFile.createNewFile()) {
+                logger.warn("Temporary file already exists or could not be created: {}", tempFile.getAbsolutePath());
+                return ProjectUtil.returnErrorMsg("Failed to create temporary file for upload.", HttpStatus.INTERNAL_SERVER_ERROR, response, Constants.FAILED);
+            }
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(multipartFile.getBytes());
+            }
+            String uploadFolderPath = serverProperties.getBpAssignmentAnsFolderName() + "/" + contentId + "/" + batchId + "/" + formId;
+            return uploadFile(tempFile, uploadFolderPath, serverProperties.getCloudPublicContainerName());
+
+        } catch (Exception e) {
+            logger.error("Failed to upload assignment answer file. Exception: ", e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErrmsg("Failed to upload assignment answer file. Exception: " + e.getMessage());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
+        } finally {
+            if (tempFile != null && tempFile.exists()) {
+                boolean deleted = tempFile.delete();
+                if (!deleted) {
+                    logger.warn("Temporary file {} could not be deleted.", tempFile.getAbsolutePath());
+                }
+            }
+        }
+    }
+
+    private SBApiResponse validateAssignmentFileInputs(MultipartFile multipartFile, String contentId, String batchId, String formId) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.ASSIGNMENT_UPLOAD_FILE);
+
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            return ProjectUtil.returnErrorMsg(Constants.FILE_EMPTY, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        if (StringUtils.isBlank(contentId)) {
+            return ProjectUtil.returnErrorMsg(Constants.INVALID_CONTENT_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        if (StringUtils.isBlank(batchId)) {
+            return ProjectUtil.returnErrorMsg(Constants.INVALID_BATCH_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        if (StringUtils.isBlank(formId)) {
+            return ProjectUtil.returnErrorMsg(Constants.INVALID_FORM_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+
+        // Validate file size (configured in KB)
+        long maxSizeBytes = serverProperties.getBpAssignmentAnsFileMaxSize() * 1024L;
+        if (multipartFile.getSize() > maxSizeBytes) {
+            return ProjectUtil.returnErrorMsg(
+                    "File size exceeds the maximum allowed limit of " + serverProperties.getBpAssignmentAnsFileMaxSize() + " KB.",
+                    HttpStatus.BAD_REQUEST, response, Constants.FAILED
+            );
+        }
+        String originalFilename = multipartFile.getOriginalFilename();
+        if (StringUtils.isEmpty(originalFilename)) {
+            return ProjectUtil.returnErrorMsg(Constants.EMPTY_FILE_NAME, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase();
+        List<String> allowedExtensions = serverProperties.getBpAssignmentAnsFileExtensions();
+
+        if (!allowedExtensions.contains(fileExtension)) {
+            return ProjectUtil.returnErrorMsg(
+                    "Unsupported file type. Allowed types: " + String.join(", ", allowedExtensions),
+                    HttpStatus.BAD_REQUEST, response, Constants.FAILED
+            );
+        }
+
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<?> readAssignmentAnsFile(String contentId, String batchId, String formId, String fileName, String userToken) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.READ_ASSIGNMENT_FILE);
+        try {
+            ResponseEntity<SBApiResponse> validationResponse = validateAssignmentReadRequest(contentId, batchId, formId, fileName, userToken);
+            if (validationResponse != null) {
+                return validationResponse;
+            }
+            String bucketName = serverProperties.getCloudPublicContainerName();
+            String folderPrefix = serverProperties.getBpAssignmentAnsFolderName();
+            String objectKey = folderPrefix + "/" + contentId + "/" + batchId + "/" + formId + "/" + fileName;
+            logger.debug("Downloading assignment answer file from bucket: {}, object: {}", bucketName, objectKey);
+            storageService.download(bucketName, objectKey, Constants.LOCAL_BASE_PATH, Option.apply(Boolean.FALSE));
+
+            Path tmpPath = Paths.get(Constants.LOCAL_BASE_PATH + fileName);
+            File localFile = tmpPath.toFile();
+            if (!localFile.exists() || localFile.isDirectory() || localFile.length() == 0) {
+                logger.warn("File not found or invalid after download: {}", localFile.getAbsolutePath());
+                return new ResponseEntity<>(
+                        ProjectUtil.returnErrorMsg(Constants.FILE_NOT_FOUND, HttpStatus.NOT_FOUND, response, Constants.FAILED),
+                        HttpStatus.NOT_FOUND
+                );
+            }
+            ByteArrayResource resource = new ByteArrayResource(Files.readAllBytes(tmpPath));
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "form-data; name=\"file\"; filename=\"" + fileName + "\"");
+            logger.info("Successfully downloaded assignment answer file: {}", fileName);
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .contentLength(tmpPath.toFile().length())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(resource);
+
+        } catch (Exception e) {
+            logger.error("Failed to download assignment answer file. Exception: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to download file: " + e.getMessage());
+        } finally {
+            try {
+                File tempFile = new File(Constants.LOCAL_BASE_PATH + fileName);
+                if (tempFile.exists()) {
+                    boolean deleted = tempFile.delete();
+                    if (!deleted) {
+                        logger.warn("Temp file {} could not be deleted.", tempFile.getAbsolutePath());
+                    }
+                }
+            } catch (Exception cleanupEx) {
+                logger.warn("Error deleting temp file: {}", cleanupEx.getMessage());
+            }
+        }
+    }
+
+    private ResponseEntity<SBApiResponse> validateAssignmentReadRequest(String contentId, String batchId, String formId, String fileName, String userToken) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.READ_ASSIGNMENT_FILE_VALIDATION);
+
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
+        if (StringUtils.isBlank(userId)) {
+            logger.error("Unauthorized access: Failed to extract user info from token");
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.UNAUTHORIZED_USER, HttpStatus.UNAUTHORIZED, response, Constants.FAILED),
+                    HttpStatus.UNAUTHORIZED
+            );
+        }
+        if (StringUtils.isBlank(contentId)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.INVALID_CONTENT_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        if (StringUtils.isBlank(batchId)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.INVALID_BATCH_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        if (StringUtils.isBlank(formId)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.INVALID_FORM_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        if (StringUtils.isBlank(fileName)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.EMPTY_FILE_NAME, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        return null;
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -603,3 +603,6 @@ org.type.field.name=sborgtype
 kafka.topics.org.user.bulk.transfer.event.group=user-bulk-transfer-group
 org.hierarchy.bulk.user.transfer.container.name=userbulktransfer
 kafka.topics.org.user.bulk.transfer.event=dev.org.user.bulk.transfer
+bp.assignment.ans.folder.name=bp-assignment
+bp.assignment.answer.file.upload.max-size-kb=5000
+bp.assignment.answer.file.upload.allowed-extensions=pdf,doc,docx


### PR DESCRIPTION
* KB-11739 | Implemented an API to upload answer files to a GCP contain… (#528)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

---------



* KB-10860 | updating validation for upload answer file to GCP for assignment (#530)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-10860 | updating validation for upload answer file to GCP for assignment

---------



* KB-11769 | implemented answer file read API for assignment with validation. (#531)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-11769 | implemented answer file read API for assignment with validation.

---------



---------