### PR TITLE
Cbrelease 4.8.30 10 nov (#544)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,25 @@
-FROM openjdk:8
+FROM eclipse-temurin:8-jdk-jammy
 
 RUN apt-get update \
     && apt-get install -y \
         curl \
         libxrender1 \
-        libjpeg62-turbo \
+        libjpeg-turbo8 \
         fontconfig \
         libxtst6 \
         xfonts-75dpi \
         xfonts-base \
-        xz-utils
+        xz-utils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb" -L -o "wkhtmltopdf.deb"
-RUN dpkg -i wkhtmltopdf.deb
+# Use the Jammy-specific .deb
+RUN curl -L -o wkhtmltox.deb \
+      https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb \
+ && dpkg -i wkhtmltox.deb \
+ && apt-get -f install -y \
+ && rm wkhtmltox.deb
+
 
 COPY sb-cb-ext-0.0.1-SNAPSHOT.jar /opt/
 #HEALTHCHECK --interval=30s --timeout=30s CMD curl --fail http://localhost:7001/actuator/health || exit 1

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM eclipse-temurin:8-jdk-jammy
 
 RUN apt update && apt install maven -y
 

--- a/src/main/java/org/sunbird/bpreports/service/BPReportConsumer.java
+++ b/src/main/java/org/sunbird/bpreports/service/BPReportConsumer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -27,18 +28,21 @@ import org.sunbird.bpreports.postgres.entity.WfStatusEntity;
 import org.sunbird.bpreports.postgres.repository.WfStatusEntityRepository;
 import org.sunbird.cassandra.utils.CassandraOperation;
 import org.sunbird.common.model.SBApiResponse;
+import org.sunbird.common.service.OutboundRequestHandlerServiceImpl;
 import org.sunbird.common.util.CbExtServerProperties;
 import org.sunbird.common.util.Constants;
 import org.sunbird.common.util.IndexerService;
 import org.sunbird.common.util.ProjectUtil.ESIndexType;
 import org.sunbird.storage.service.StorageService;
 
+import javax.ws.rs.core.MediaType;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Component
 public class BPReportConsumer {
@@ -62,6 +66,9 @@ public class BPReportConsumer {
 
     @Autowired
     StorageService storageService;
+
+    @Autowired
+    OutboundRequestHandlerServiceImpl outboundRequestHandlerService;
 
 
     @KafkaListener(topics = "${kafka.topic.bp.report}", groupId = "${kafka.topic.bp.report.group}")
@@ -131,33 +138,42 @@ public class BPReportConsumer {
             List<WfStatusEntity> wfStatusEntities = getAllWfStatusEntitiesByBatchId(batchId);
             if (CollectionUtils.isEmpty(wfStatusEntities)) {
                 logger.info("No workflow status entities found for batchId: {}", batchId);
-                updateDataBase(adminOrgId, courseId, batchId, reportRequester, null, null, Constants.COMPLETED_UPPER_CASE, 0, 0, 0, new Date());
-                return;
             }
 
             String surveyId = (String) request.get(Constants.SURVEY_ID);
-            // Get BP survey data if survey ID is present
-            Map<String, Object> dataObject = getSurveyData(surveyId, null);
+
+            // Get BP survey form questions if survey ID is present
+            List<Map<String, Object>> formQuestions = new ArrayList<>();
+            if (StringUtils.isNotBlank(surveyId)) {
+                formQuestions = getFormQuestionsList(surveyId);
+                if (CollectionUtils.isEmpty(formQuestions)) {
+                    logger.info("Survey form questions not found for surveyId: {}", surveyId);
+                } else {
+                    logger.info("Loaded {} survey form questions for surveyId: {}", formQuestions.size(), surveyId);
+                }
+            } else {
+                logger.info("surveyId is null or empty. BP enrolment report will be generated using profile survey details only.");
+            }
 
             //Get BP Profile survey data
             String batchAttributesStr = (String) batchReadResp.get(Constants.BATCH_ATTRIBUTES);
-            if (batchAttributesStr == null) {
-                logger.info("No batch attributes found for batchId: {}", batchId);
+            if (StringUtils.isEmpty(batchAttributesStr)) {
+                logger.error("No batch attributes found for batchId: {}", batchId);
                 updateDataBase(adminOrgId, courseId, batchId, reportRequester, null, null, Constants.FAILED_UPPERCASE, 0, 0, 0, new Date());
                 return;
             }
             Map<String, Object> batchAttributes = mapper.readValue(batchAttributesStr, new TypeReference<Map<String, Object>>() {
             });
             String profileSurveyId = (String) batchAttributes.get(Constants.PROFILE_SURVEY_ID);
-            Map<String, Object> profileSurveyData = getSurveyResponse(profileSurveyId);
+            Map<String, Object> userBatchFormData = getUserBatchFormData(profileSurveyId);
 
             // Create header row and apply styles
             Sheet sheet = workbook.createSheet("Enrollment Report");
             if (Constants.MDO_ADMIN.equalsIgnoreCase(reportRequester) || Constants.MDO_LEADER.equalsIgnoreCase(reportRequester)) {
-                createHeaderRowWithDefaultFields(workbook, sheet, dataObject, headerKeyMapping);
+                createHeaderRowWithDefaultFields(workbook, sheet, formQuestions, headerKeyMapping);
             } else {
                 mandatoryProfileFieldsKeyMappingForPC(batchAttributes, headerKeyMapping);
-                createHeaderRow(workbook, sheet, dataObject, headerKeyMapping);
+                createHeaderRow(workbook, sheet, formQuestions, headerKeyMapping);
             }
             int rowNum = 1;
 
@@ -193,10 +209,10 @@ public class BPReportConsumer {
                     } else {
                         pendingUserCount++;
                     }
-                    Map<String, Object> userSurveyDataObject = StringUtils.isNotEmpty(surveyId) ? getSurveyData(surveyId, userId) : new HashMap<>();
+                    Map<String, Object> userQuestionsAnswer = StringUtils.isNotEmpty(surveyId) ? getUserQuestionsAnswer(surveyId, userId, courseId) : new HashMap<>();
                     Map<String, Object> userInfo = getUserInfo(userDetailsObj);
                     String enrollmentStatus = getEnrollmentStatus(currentStatus);
-                    processReport(userInfo, enrollmentStatus, MapUtils.isNotEmpty(userSurveyDataObject) ? userSurveyDataObject : new HashMap<>(), (Map<String, Object>) profileSurveyData.get(userId), sheet, headerKeyMapping, rowNum);
+                    processReport(userInfo, enrollmentStatus, MapUtils.isNotEmpty(userQuestionsAnswer) ? userQuestionsAnswer : new HashMap<>(), (Map<String, Object>) userBatchFormData.get(userId), sheet, headerKeyMapping, rowNum);
 
                 } catch (Exception e) {
                     logger.error("Error processing report for userId: {}", userId, e);
@@ -212,17 +228,61 @@ public class BPReportConsumer {
         }
     }
 
-    private Map<String, Object> getSurveyData(String surveyId, String userId) {
+    private Map<String, Object> getUserQuestionsAnswer(String surveyId, String userId, String contextId) {
         if (StringUtils.isNotEmpty(surveyId)) {
-            List<Map<String, Object>> surveyResponse = getSurveyResponse(surveyId, userId);
-            if (!CollectionUtils.isEmpty(surveyResponse)) {
-                Map<String, Object> firstResponse = surveyResponse.get(0);
-                if (firstResponse != null && firstResponse.get(Constants.DATA_OBJECT) instanceof Map) {
-                    return (Map<String, Object>) firstResponse.get(Constants.DATA_OBJECT);
+            List<Map<String, Object>> userFormData = getUserFormData(surveyId, userId, contextId);
+            if (!CollectionUtils.isEmpty(userFormData)) {
+                Map<String, Object> firstResponse = userFormData.get(0);
+                if (!CollectionUtils.isEmpty((Collection<?>) firstResponse.get(Constants.RESPONSES))) {
+                    List<Map<String, Object>> userFormQuestionsAnswerList =
+                            (List<Map<String, Object>>) firstResponse.get(Constants.RESPONSES);
+
+                    return userFormQuestionsAnswerList.stream()
+                            .filter(Objects::nonNull)
+                            .filter(qa -> qa.get(Constants.QUESTION) != null)
+                            .collect(Collectors.toMap(
+                                    qa -> (String) qa.get(Constants.QUESTION),
+                                    qa -> qa.get(Constants.ANSWER),
+                                    (existing, replacement) -> replacement,
+                                    LinkedHashMap::new //preserves order
+                            ));
                 }
             }
         }
-        return new HashMap<>();
+        return new LinkedHashMap<>();
+    }
+
+    private List<Map<String, Object>> getFormQuestionsList(String formId) {
+        String url = String.format("%s%s?%s=%s",
+                serverProperties.getFormServiceHost(),
+                serverProperties.getGetFormByIdV2Path(),
+                Constants.FORM_ID,
+                formId);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        headers.put(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+
+        Map<String, Object> formReadResponse = (Map<String, Object>) outboundRequestHandlerService.fetchResultUsingGet(url, headers);
+        if (MapUtils.isEmpty(formReadResponse) || !formReadResponse.containsKey(Constants.RESULT)) {
+            return Collections.emptyList();
+        }
+        Map<String, Object> result = (Map<String, Object>) formReadResponse.get(Constants.RESULT);
+
+        Map<String, Object> response = (Map<String, Object>) result.get(Constants.RESPONSE);
+        if (MapUtils.isEmpty(response) || !response.containsKey(Constants.FIELDS)) {
+            return Collections.emptyList();
+        }
+
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) response.get(Constants.FIELDS);
+        if (CollectionUtils.isEmpty(fields)) {
+            return Collections.emptyList();
+        }
+
+        return fields.stream()
+                .filter(field -> Constants.QUESTION.equalsIgnoreCase(
+                        (String) field.get(Constants.CONTEXT_TYPE)))
+                .collect(Collectors.toList());
     }
 
     private Map<String, Object> getBatchDetails(String courseId, String batchId) {
@@ -408,64 +468,53 @@ public class BPReportConsumer {
         return null;
     }
 
-    private List<Map<String, Object>> getSurveyResponse(String surveyId, String userId) {
+    private List<Map<String, Object>> getUserFormData(String surveyId, String userId, String contextId) {
         List<Map<String, Object>> result = new ArrayList<>();
         try {
-            // Query construction
+            // Build the search request
             SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 
-            // If userId is null, fetch only one record
-            if (userId == null) {
-                sourceBuilder.size(1);  // Set the result size to 1
-            }
+            // Build the base query
+            BoolQueryBuilder finalQuery = QueryBuilders.boolQuery()
+                    .must(QueryBuilders.termQuery(Constants.FORM_ID, surveyId))
+                    .must(QueryBuilders.termQuery(Constants.CONTEXT_ID_CAMEL, contextId))
+                    .must(QueryBuilders.termQuery(Constants.SUBMITTED_BY, userId));
 
-            // Build the query for surveyId
-            MatchQueryBuilder matchFormIdQuery = QueryBuilders.matchQuery(Constants.FORM_ID, surveyId);
-            BoolQueryBuilder boolQuery = new BoolQueryBuilder().must(matchFormIdQuery);
-
-            // If userId is provided, add it to the query
-            if (userId != null) {
-                MatchQueryBuilder matchUserIdQuery = QueryBuilders.matchQuery(Constants.UPDATED_BY, userId);
-                boolQuery.must(matchUserIdQuery);
-            }
-
-            sourceBuilder.query(boolQuery);
-
-            // Sorting by timestamp in ascending order
-            sourceBuilder.sort("timestamp", SortOrder.DESC);
+            // Apply query and sorting
+            sourceBuilder.query(finalQuery);
+            sourceBuilder.sort(Constants.SUBMITTED_DATE, SortOrder.DESC); // Sorting by timestamp in descending order
 
             // Execute the search request
             SearchResponse searchResponse = indexerService.getEsResult(
-                    serverProperties.getIgotEsUserFormIndex(),
+                    serverProperties.getUserFormDataIndexV2(),
                     serverProperties.getEsFormIndexType(),
                     sourceBuilder,
                     ESIndexType.IGOT_ES
             );
 
+            // Process search results
             if (searchResponse != null && searchResponse.getHits().getHits().length > 0) {
-                // Process each record (hit)
                 for (SearchHit hit : searchResponse.getHits().getHits()) {
                     Map<String, Object> sourceMap = hit.getSourceAsMap();
                     if (sourceMap != null) {
-                        // Put the result in the map using the "updatedBy" field as the key
                         result.add(sourceMap);
                     }
                 }
             } else {
-                logger.warn("No results found for surveyId: {}", surveyId);
+                logger.warn("No results found for surveyId: {} and userId: {}", surveyId, userId);
             }
 
         } catch (IOException e) {
-            logger.error("Error while processing user form response for surveyId: {}", surveyId, e);
+            logger.error("Error while processing user form response for surveyId: {} and userId: {}", surveyId, userId, e);
         }
 
         return result;
     }
 
-    private void processReport(Map<String, Object> userInfo, String enrollmentStatus, Map<String, Object> userSurveyDataObject, Map<String, Object> userBatchFormData, Sheet sheet, Map<String, Object> headerKeyMapping, int rowNum) {
+    private void processReport(Map<String, Object> userInfo, String enrollmentStatus, Map<String, Object> userQuestionsAnswer, Map<String, Object> userBatchFormData, Sheet sheet, Map<String, Object> headerKeyMapping, int rowNum) {
         try {
             // Create a new sheet or get existing one based on requirement
-            Map<String, Object> reportInfo = prepareReportInfo(userInfo, enrollmentStatus, userSurveyDataObject, userBatchFormData);
+            Map<String, Object> reportInfo = prepareReportInfo(userInfo, enrollmentStatus, userQuestionsAnswer, userBatchFormData);
 
             // Add user data to the sheet
             fillDataRows(sheet, rowNum, headerKeyMapping, reportInfo);
@@ -476,7 +525,7 @@ public class BPReportConsumer {
     }
 
     private void createHeaderRow(Workbook workbook, Sheet sheet,
-                                 Map<String, Object> formQuestionsMap, Map<String, Object> headerKeyMapping) throws IOException {
+                                 List<Map<String, Object>> formQuestionsListMap, Map<String, Object> headerKeyMapping) throws IOException {
 
         Row headerRow = sheet.createRow(0);
         CellStyle headerStyle = createHeaderCellStyle(workbook);
@@ -518,11 +567,8 @@ public class BPReportConsumer {
         List<String> formQuestionsList = new ArrayList<>();
 
         // Populate header row with form questions that are not already mapped
-        for (Map.Entry<String, Object> entry : formQuestionsMap.entrySet()) {
-            String questionKey = entry.getKey();
-            if (Constants.COURSE_ID_AND_NAME.equalsIgnoreCase(questionKey)) {
-                continue;
-            }
+        for (Map<String, Object> question : formQuestionsListMap) {
+            String questionKey = (String) question.get(Constants.NAME);
             if (!headerKeyMapping.containsKey(questionKey)) {
                 cell = headerRow.createCell(currentColumnIndex++);
                 cell.setCellValue(questionKey.trim());
@@ -532,7 +578,7 @@ public class BPReportConsumer {
             }
         }
 
-        headerKeyMapping.put("formQuestions", formQuestionsList);
+        headerKeyMapping.put(Constants.FORM_QUESTIONS, formQuestionsList);
     }
 
     private CellStyle createHeaderCellStyle(Workbook workbook) {
@@ -551,8 +597,8 @@ public class BPReportConsumer {
         int cellNum = 0;
 
         for (String columnKey : headerKeyMapping.keySet()) {
-            if (columnKey.equalsIgnoreCase("formQuestions")) {
-                Map<String, Object> formAllQuestionsAns = (Map<String, Object>) reportInfo.get(columnKey);
+            if (columnKey.equalsIgnoreCase(Constants.FORM_QUESTIONS)) {
+                Map<String, Object> formAllQuestionsAns = (Map<String, Object>) reportInfo.get(Constants.FORM_QUESTIONS_ANSWER);
                 List<String> formAllRequiredQuestionskey = (List<String>) headerKeyMapping.get(columnKey);
 
                 if (!CollectionUtils.isEmpty(formAllRequiredQuestionskey)) {
@@ -575,25 +621,23 @@ public class BPReportConsumer {
         }
     }
 
-    private Map<String, Object> prepareReportInfo(Map<String, Object> userInfo, String enrollmentStatus, Map<String, Object> userSurveyDataObject, Map<String, Object> userProfileSurveyData) {
+    private Map<String, Object> prepareReportInfo(Map<String, Object> userInfo, String enrollmentStatus, Map<String, Object> userQuestionsAnswer, Map<String, Object> userBatchFormData) {
 
         Map<String, Object> reportInfo = new HashMap<>(userInfo);
         reportInfo.put(Constants.ENROLLMENT_STATUS, enrollmentStatus);
 
         // Extract and add survey questions and ans.
-        if (MapUtils.isNotEmpty(userSurveyDataObject)) {
-            Map<String, Object> formQuestions = new LinkedHashMap<>(userSurveyDataObject);
-            reportInfo.put("formQuestions", formQuestions);
+        if (MapUtils.isNotEmpty(userQuestionsAnswer)) {
+            reportInfo.put(Constants.FORM_QUESTIONS_ANSWER, userQuestionsAnswer);
         }
 
         // Add batch for questions and ans.
-        if (MapUtils.isNotEmpty(userProfileSurveyData)) {
-            Map<String, Object> userProfileSurveyDataObject = (Map<String, Object>) userProfileSurveyData.get(Constants.DATA_OBJECT);
-            if (userProfileSurveyDataObject.containsKey(Constants.GROUP_TITLE_CASE)) {
-                reportInfo.put(Constants.GROUP_TITLE_CASE, userProfileSurveyDataObject.get(Constants.GROUP_TITLE_CASE));
+        if (MapUtils.isNotEmpty(userBatchFormData)) {
+            if (userBatchFormData.containsKey(Constants.GROUP_TITLE_CASE)) {
+                reportInfo.put(Constants.GROUP_TITLE_CASE, userBatchFormData.get(Constants.GROUP_TITLE_CASE));
             }
-            if (userProfileSurveyDataObject.containsKey(Constants.DESIGNATION_TITLE_CASE)) {
-                reportInfo.put(Constants.DESIGNATION_TITLE_CASE, userProfileSurveyDataObject.get(Constants.DESIGNATION_TITLE_CASE));
+            if (userBatchFormData.containsKey(Constants.DESIGNATION_TITLE_CASE)) {
+                reportInfo.put(Constants.DESIGNATION_TITLE_CASE, userBatchFormData.get(Constants.DESIGNATION_TITLE_CASE));
             }
 
         }
@@ -639,7 +683,7 @@ public class BPReportConsumer {
     }
 
     private void createHeaderRowWithDefaultFields(Workbook workbook, Sheet sheet,
-                                                  Map<String, Object> formQuestionsMap, Map<String, Object> headerKeyMapping) throws IOException {
+                                                  List<Map<String, Object>> formQuestionsListMap, Map<String, Object> headerKeyMapping) throws IOException {
 
         String bpReportDefaultFieldsStr = serverProperties.getBpEnrolmentReportDefaultFields();
         Map<String, String> bpReportDefaultFieldsMap = mapper.readValue(bpReportDefaultFieldsStr, new TypeReference<LinkedHashMap<String, Object>>() {
@@ -686,11 +730,8 @@ public class BPReportConsumer {
         List<String> formQuestionsList = new ArrayList<>();
 
         // Populate header row with form questions that are not already mapped
-        for (Map.Entry<String, Object> entry : formQuestionsMap.entrySet()) {
-            String questionKey = entry.getKey();
-            if (Constants.COURSE_ID_AND_NAME.equalsIgnoreCase(questionKey)) {
-                continue;
-            }
+        for (Map<String, Object> question : formQuestionsListMap) {
+            String questionKey = (String) question.get(Constants.NAME);
             if (!headerKeyMapping.containsKey(questionKey)) {
                 cell = headerRow.createCell(currentColumnIndex++);
                 cell.setCellValue(questionKey.trim());
@@ -700,7 +741,7 @@ public class BPReportConsumer {
             }
         }
 
-        headerKeyMapping.put("formQuestions", formQuestionsList);
+        headerKeyMapping.put(Constants.FORM_QUESTIONS, formQuestionsList);
     }
 
     private void mandatoryProfileFieldsKeyMappingForPC(Map<String, Object> batchAttributes, Map<String, Object> headerKeyMapping) throws IOException {
@@ -730,45 +771,68 @@ public class BPReportConsumer {
         }
     }
 
-    private Map<String, Object> getSurveyResponse(String surveyId) {
-        Map<String, Object> resultMap = new HashMap<>();
+    private Map<String, Object> getUserBatchFormData(String surveyId) {
+        Map<String, Object> resultMap = new LinkedHashMap<>();
+        final int BATCH_SIZE = 500;
+        Object[] searchAfter = null;
+
         try {
-            // Query construction
-            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+            while (true) {
+                SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 
-            // Build the query for surveyId
-            MatchQueryBuilder matchFormIdQuery = QueryBuilders.matchQuery(Constants.FORM_ID, surveyId);
-            BoolQueryBuilder boolQuery = new BoolQueryBuilder().must(matchFormIdQuery);
-            sourceBuilder.query(boolQuery);
+                // Query
+                BoolQueryBuilder finalQuery = QueryBuilders.boolQuery()
+                        .must(QueryBuilders.termQuery(Constants.FORM_ID, surveyId));
 
-            // Sorting by timestamp in ascending order
-            sourceBuilder.sort("timestamp", SortOrder.DESC);
+                sourceBuilder.query(finalQuery);
+                sourceBuilder.sort(Constants.SUBMITTED_DATE, SortOrder.DESC);
+                sourceBuilder.size(BATCH_SIZE);
 
-            // Execute the search request
-            SearchResponse searchResponse = indexerService.getEsResult(
-                    serverProperties.getIgotEsUserFormIndex(),
-                    serverProperties.getEsFormIndexType(),
-                    sourceBuilder,
-                    ESIndexType.IGOT_ES
-            );
+                if (searchAfter != null) {
+                    sourceBuilder.searchAfter(searchAfter);
+                }
 
-            if (searchResponse != null && searchResponse.getHits().getHits().length > 0) {
-                // Process each record (hit)
-                for (SearchHit hit : searchResponse.getHits().getHits()) {
+                SearchResponse searchResponse = indexerService.getEsResult(
+                        serverProperties.getUserFormDataIndexV2(),
+                        serverProperties.getEsFormIndexType(),
+                        sourceBuilder,
+                        ESIndexType.IGOT_ES
+                );
+
+                SearchHit[] hits = searchResponse.getHits().getHits();
+                if (hits == null || hits.length == 0) {
+                    break; // stop when no records found
+                }
+
+                for (SearchHit hit : hits) {
                     Map<String, Object> sourceMap = hit.getSourceAsMap();
                     if (sourceMap != null) {
-                        // Put the result in the map using the "updatedBy" field as the key
-                        resultMap.put((String) sourceMap.get(Constants.UPDATED_BY), sourceMap);
+                        List<Map<String, Object>> questionsAnswerList =
+                                (List<Map<String, Object>>) sourceMap.get(Constants.RESPONSES);
+
+                        Map<String, Object> questionsAnswerMap = questionsAnswerList.stream()
+                                .filter(Objects::nonNull)
+                                .filter(qa -> qa.get(Constants.QUESTION) != null)
+                                .collect(Collectors.toMap(
+                                        qa -> (String) qa.get(Constants.QUESTION),
+                                        qa -> qa.get(Constants.ANSWER),
+                                        (existing, replacement) -> replacement,
+                                        LinkedHashMap::new
+                                ));
+
+                        resultMap.put((String) sourceMap.get(Constants.SUBMITTED_BY), questionsAnswerMap);
                     }
                 }
-            } else {
-                logger.warn("No results found for surveyId: {}", surveyId);
+
+                // Prepare next search_after value (use last hit’s sort values)
+                searchAfter = hits[hits.length - 1].getSortValues();
             }
 
         } catch (IOException e) {
             logger.error("Error while processing user form response for surveyId: {}", surveyId, e);
         }
 
+        logger.info("Total {} records found for batch surveyId: {}", resultMap.size(), surveyId);
         return resultMap;
     }
 }

--- a/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
+++ b/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
@@ -1136,8 +1136,25 @@ public class CbExtServerProperties {
     @Value("${kafka.topics.org.user.bulk.transfer.event}")
     private String orgHierarchyUserBulkTransferTopic;
 
+    @Value("${bp.assignment.ans.folder.name}")
+    private String bpAssignmentAnsFolderName;
+
+    @Value("${bp.assignment.answer.file.upload.max-size-kb}")
+    private long bpAssignmentAnsFileMaxSize;
+
+    @Value("#{'${bp.assignment.answer.file.upload.allowed-extensions}'.split(',')}")
+    private List<String> bpAssignmentAnsFileExtensions;
     @Value("${org.hierarchy.identifier.regex.pattern}")
     private String orgIdRegexPattern;
+
+    @Value("${igot.es.user.form.data.index.v2}")
+    private String userFormDataIndexV2;
+
+    @Value("${form.service.host}")
+    private String formServiceHost;
+
+    @Value("${get.v2.formbyid.path}")
+    private String getFormByIdV2Path;
 
     @Value("${org.level.hierarchy.cache.key.ttl}")
     private int orgLevelHierarchyCacheKeyTTL;
@@ -3836,8 +3853,56 @@ public class CbExtServerProperties {
         return orgHierarchyUserBulkTransferTopic;
     }
 
+    public String getBpAssignmentAnsFolderName() {
+        return bpAssignmentAnsFolderName;
+    }
+
+    public void setBpAssignmentAnsFolderName(String bpAssignmentAnsFolderName) {
+        this.bpAssignmentAnsFolderName = bpAssignmentAnsFolderName;
+    }
+
+    public long getBpAssignmentAnsFileMaxSize() {
+        return bpAssignmentAnsFileMaxSize;
+    }
+
+    public void setBpAssignmentAnsFileMaxSize(long bpAssignmentAnsFileMaxSize) {
+        this.bpAssignmentAnsFileMaxSize = bpAssignmentAnsFileMaxSize;
+    }
+
+    public List<String> getBpAssignmentAnsFileExtensions() {
+        return bpAssignmentAnsFileExtensions;
+    }
+
+    public void setBpAssignmentAnsFileExtensions(List<String> bpAssignmentAnsFileExtensions) {
+        this.bpAssignmentAnsFileExtensions = bpAssignmentAnsFileExtensions;
+    }
+
     public String getOrgIdRegexPattern() {
         return orgIdRegexPattern;
+    }
+
+    public String getUserFormDataIndexV2() {
+        return userFormDataIndexV2;
+    }
+
+    public void setUserFormDataIndexV2(String userFormDataIndexV2) {
+        this.userFormDataIndexV2 = userFormDataIndexV2;
+    }
+
+    public String getFormServiceHost() {
+        return formServiceHost;
+    }
+
+    public void setFormServiceHost(String formServiceHost) {
+        this.formServiceHost = formServiceHost;
+    }
+
+    public String getGetFormByIdV2Path() {
+        return getFormByIdV2Path;
+    }
+
+    public void setGetFormByIdV2Path(String getFormByIdV2Path) {
+        this.getFormByIdV2Path = getFormByIdV2Path;
     }
 
     public int getOrgLevelHierarchyCacheKeyTTL() {

--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -123,6 +123,7 @@ public class Constants {
 	public static final Float ASSESSMENT_PASS_SCORE = 60.0f;
 	public static final String DATE_FORMAT = "yyyy-mm-dd hh:mm:ss";
 	public static final String RESPONSE = "response";
+    public static final String RESPONSES = "responses";
 	public static final String STAFF = "staff";
 	public static final String API_STAFF_POSITION_ADD = "api.staff.position.add";
 	public static final String API_STAFF_POSITION_UPDATE = "api.staff.position.update";
@@ -1435,6 +1436,17 @@ public class Constants {
     public static final String HEADER_ROW_NOT_FOUND = "Header row not found in Excel file";
     public static final String ORGANIZATION_MISMATCH = "User's current organization does not match with the root organization. Please verify the organization hierarchy.";
     public static final String EMPTY_FILE = "The uploaded file is empty or could not be processed";
+    public static final String ASSIGNMENT_UPLOAD_FILE = "api.blended_program.Assignment.ans.fileUpload";
+    public static final String FILE_EMPTY = "Uploaded file is empty.";
+    public static final String INVALID_CONTENT_ID = "Invalid or missing content ID.";
+    public static final String INVALID_BATCH_ID = "Invalid or missing batch ID.";
+    public static final String INVALID_FORM_ID = "Invalid or missing form ID.";
+    public static final String FILE = "file";
+    public static final String EMPTY_FILE_NAME = "The uploaded file name is empty or could not be processed";
+    public static final String FILE_NOT_FOUND = "File not found for the given details.";
+    public static final String READ_ASSIGNMENT_FILE = "api.assignment.answer.read";
+    public static final String READ_ASSIGNMENT_FILE_VALIDATION = "api.assignment.answer.read.validation";
+    public static final String UNAUTHORIZED_USER = "Unauthorized user or invalid token.";
     public static final String NULL_STRING = "null";
     public static final String EMPTY_JSON_OBJECT = "{}";
     public static final String EMPTY_JSON_ARRAY = "[]";
@@ -1446,5 +1458,9 @@ public class Constants {
     private Constants() {
 		throw new IllegalStateException("Utility class");
 	}
+    public static final String SUBMITTED_BY = "submittedBy";
+    public static final String FORM_QUESTIONS_ANSWER = "formQuestionsAnswer";
+    public static final String FORM_QUESTIONS = "formQuestions";
+    public static final String SUBMITTED_DATE = "submittedDate";
 
 }

--- a/src/main/java/org/sunbird/common/util/ProjectUtil.java
+++ b/src/main/java/org/sunbird/common/util/ProjectUtil.java
@@ -261,6 +261,14 @@ public class ProjectUtil {
 		return headers;
 	}
 
+    public static SBApiResponse returnErrorMsg(String errMsg, HttpStatus httpStatus, SBApiResponse response, String status) {
+        response.getParams().setStatus(status);
+        response.getParams().setErrmsg(errMsg);
+        response.setResponseCode(httpStatus);
+        response.getResult().put("message", errMsg);
+        return response;
+    }
+
 	public static enum ESIndexType {
 		SUNBIRD_ES("sunbird_es"), USER_ES("user_es"), IGOT_ES("igot_es");
 		private String indexName;

--- a/src/main/java/org/sunbird/storage/controller/StorageController.java
+++ b/src/main/java/org/sunbird/storage/controller/StorageController.java
@@ -120,4 +120,26 @@ public class StorageController {
 		SBApiResponse uploadResponse = storageService.uploadImageToGCPContainer(multipartFile, requestBody,authUserToken);
 		return new ResponseEntity<>(uploadResponse, uploadResponse.getResponseCode());
 	}
+
+    @PostMapping("/v1/bp/assignment/answer/{contentId}/{batchId}/{formId}")
+    public ResponseEntity<SBApiResponse> uploadAssignmentFile(
+            @RequestParam(value = Constants.FILE, required = true) MultipartFile multipartFile,
+            @PathVariable(value = Constants.CONTENT_ID_KEY, required = true) String contentId,
+            @PathVariable(value = Constants.BATCH_ID, required = true) String batchId,
+            @PathVariable(value = Constants.FORM_ID, required = true) String formId) {
+        SBApiResponse uploadResponse = storageService.uploadAssignmentAnsFile(multipartFile, contentId, batchId, formId);
+        return new ResponseEntity<>(uploadResponse, uploadResponse.getResponseCode());
+    }
+
+    @GetMapping("/v1/bp/assignment/answer/read/file")
+    public ResponseEntity<?> readAssignmentAnswerFile(
+            @RequestParam(value = "contentId", required = true) String contentId,
+            @RequestParam(value = "batchId", required = true) String batchId,
+            @RequestParam(value = "formId", required = true) String formId,
+            @RequestParam(value = "fileName", required = true) String fileName,
+            @RequestHeader(Constants.X_AUTH_TOKEN) String userToken){
+        return storageService.readAssignmentAnsFile(contentId, batchId, formId, fileName, userToken);
+    }
+
+
 }

--- a/src/main/java/org/sunbird/storage/service/StorageService.java
+++ b/src/main/java/org/sunbird/storage/service/StorageService.java
@@ -52,4 +52,9 @@ public interface StorageService {
 	 * @return the response object containing the result of the upload operation
 	 */
 	SBApiResponse uploadImageToGCPContainer(MultipartFile multipartFile, Map<String, Object> requestBody, String authUserToken);
+
+    SBApiResponse uploadAssignmentAnsFile(MultipartFile multipartFile, String contentId, String batchId, String formId);
+
+    ResponseEntity<?> readAssignmentAnsFile(String contentId, String batchId, String formId, String fileName, String userToken);
+
 }

--- a/src/main/java/org/sunbird/storage/service/StorageServiceImpl.java
+++ b/src/main/java/org/sunbird/storage/service/StorageServiceImpl.java
@@ -9,9 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import javax.annotation.PostConstruct;
 
@@ -672,4 +670,173 @@ public class StorageServiceImpl implements StorageService {
 		response.getParams().setErrmsg(Constants.USER_ID_DOESNT_EXIST);
 		response.setResponseCode(responseCode);
 	}
+
+    @Override
+    public SBApiResponse uploadAssignmentAnsFile(MultipartFile multipartFile, String contentId, String batchId, String formId) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.ASSIGNMENT_UPLOAD_FILE);
+
+        SBApiResponse validationError = validateAssignmentFileInputs(multipartFile, contentId, batchId, formId);
+        if (validationError != null) {
+            return validationError;
+        }
+        File tempFile = null;
+        try {
+            tempFile = new File(System.currentTimeMillis() + "_" + multipartFile.getOriginalFilename());
+            if (!tempFile.createNewFile()) {
+                logger.warn("Temporary file already exists or could not be created: {}", tempFile.getAbsolutePath());
+                return ProjectUtil.returnErrorMsg("Failed to create temporary file for upload.", HttpStatus.INTERNAL_SERVER_ERROR, response, Constants.FAILED);
+            }
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(multipartFile.getBytes());
+            }
+            String uploadFolderPath = serverProperties.getBpAssignmentAnsFolderName() + "/" + contentId + "/" + batchId + "/" + formId;
+            return uploadFile(tempFile, uploadFolderPath, serverProperties.getCloudPublicContainerName());
+
+        } catch (Exception e) {
+            logger.error("Failed to upload assignment answer file. Exception: ", e);
+            response.getParams().setStatus(Constants.FAILED);
+            response.getParams().setErrmsg("Failed to upload assignment answer file. Exception: " + e.getMessage());
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
+            return response;
+        } finally {
+            if (tempFile != null && tempFile.exists()) {
+                boolean deleted = tempFile.delete();
+                if (!deleted) {
+                    logger.warn("Temporary file {} could not be deleted.", tempFile.getAbsolutePath());
+                }
+            }
+        }
+    }
+
+    private SBApiResponse validateAssignmentFileInputs(MultipartFile multipartFile, String contentId, String batchId, String formId) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.ASSIGNMENT_UPLOAD_FILE);
+
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            return ProjectUtil.returnErrorMsg(Constants.FILE_EMPTY, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        if (StringUtils.isBlank(contentId)) {
+            return ProjectUtil.returnErrorMsg(Constants.INVALID_CONTENT_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        if (StringUtils.isBlank(batchId)) {
+            return ProjectUtil.returnErrorMsg(Constants.INVALID_BATCH_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        if (StringUtils.isBlank(formId)) {
+            return ProjectUtil.returnErrorMsg(Constants.INVALID_FORM_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+
+        // Validate file size (configured in KB)
+        long maxSizeBytes = serverProperties.getBpAssignmentAnsFileMaxSize() * 1024L;
+        if (multipartFile.getSize() > maxSizeBytes) {
+            return ProjectUtil.returnErrorMsg(
+                    "File size exceeds the maximum allowed limit of " + serverProperties.getBpAssignmentAnsFileMaxSize() + " KB.",
+                    HttpStatus.BAD_REQUEST, response, Constants.FAILED
+            );
+        }
+        String originalFilename = multipartFile.getOriginalFilename();
+        if (StringUtils.isEmpty(originalFilename)) {
+            return ProjectUtil.returnErrorMsg(Constants.EMPTY_FILE_NAME, HttpStatus.BAD_REQUEST, response, Constants.FAILED);
+        }
+        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase();
+        List<String> allowedExtensions = serverProperties.getBpAssignmentAnsFileExtensions();
+
+        if (!allowedExtensions.contains(fileExtension)) {
+            return ProjectUtil.returnErrorMsg(
+                    "Unsupported file type. Allowed types: " + String.join(", ", allowedExtensions),
+                    HttpStatus.BAD_REQUEST, response, Constants.FAILED
+            );
+        }
+
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<?> readAssignmentAnsFile(String contentId, String batchId, String formId, String fileName, String userToken) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.READ_ASSIGNMENT_FILE);
+        try {
+            ResponseEntity<SBApiResponse> validationResponse = validateAssignmentReadRequest(contentId, batchId, formId, fileName, userToken);
+            if (validationResponse != null) {
+                return validationResponse;
+            }
+            String bucketName = serverProperties.getCloudPublicContainerName();
+            String folderPrefix = serverProperties.getBpAssignmentAnsFolderName();
+            String objectKey = folderPrefix + "/" + contentId + "/" + batchId + "/" + formId + "/" + fileName;
+            logger.debug("Downloading assignment answer file from bucket: {}, object: {}", bucketName, objectKey);
+            storageService.download(bucketName, objectKey, Constants.LOCAL_BASE_PATH, Option.apply(Boolean.FALSE));
+
+            Path tmpPath = Paths.get(Constants.LOCAL_BASE_PATH + fileName);
+            File localFile = tmpPath.toFile();
+            if (!localFile.exists() || localFile.isDirectory() || localFile.length() == 0) {
+                logger.warn("File not found or invalid after download: {}", localFile.getAbsolutePath());
+                return new ResponseEntity<>(
+                        ProjectUtil.returnErrorMsg(Constants.FILE_NOT_FOUND, HttpStatus.NOT_FOUND, response, Constants.FAILED),
+                        HttpStatus.NOT_FOUND
+                );
+            }
+            ByteArrayResource resource = new ByteArrayResource(Files.readAllBytes(tmpPath));
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "form-data; name=\"file\"; filename=\"" + fileName + "\"");
+            logger.info("Successfully downloaded assignment answer file: {}", fileName);
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .contentLength(tmpPath.toFile().length())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(resource);
+
+        } catch (Exception e) {
+            logger.error("Failed to download assignment answer file. Exception: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to download file: " + e.getMessage());
+        } finally {
+            try {
+                File tempFile = new File(Constants.LOCAL_BASE_PATH + fileName);
+                if (tempFile.exists()) {
+                    boolean deleted = tempFile.delete();
+                    if (!deleted) {
+                        logger.warn("Temp file {} could not be deleted.", tempFile.getAbsolutePath());
+                    }
+                }
+            } catch (Exception cleanupEx) {
+                logger.warn("Error deleting temp file: {}", cleanupEx.getMessage());
+            }
+        }
+    }
+
+    private ResponseEntity<SBApiResponse> validateAssignmentReadRequest(String contentId, String batchId, String formId, String fileName, String userToken) {
+        SBApiResponse response = ProjectUtil.createDefaultResponse(Constants.READ_ASSIGNMENT_FILE_VALIDATION);
+
+        String userId = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
+        if (StringUtils.isBlank(userId)) {
+            logger.error("Unauthorized access: Failed to extract user info from token");
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.UNAUTHORIZED_USER, HttpStatus.UNAUTHORIZED, response, Constants.FAILED),
+                    HttpStatus.UNAUTHORIZED
+            );
+        }
+        if (StringUtils.isBlank(contentId)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.INVALID_CONTENT_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        if (StringUtils.isBlank(batchId)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.INVALID_BATCH_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        if (StringUtils.isBlank(formId)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.INVALID_FORM_ID, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        if (StringUtils.isBlank(fileName)) {
+            return new ResponseEntity<>(
+                    ProjectUtil.returnErrorMsg(Constants.EMPTY_FILE_NAME, HttpStatus.BAD_REQUEST, response, Constants.FAILED),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+        return null;
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -93,6 +93,11 @@ user_index_name=user_alias
 igot.es.user.form.index=fs-forms-data
 es.form.index.type=_doc
 
+#form-service
+form.service.host=http://form-service:8099/
+igot.es.user.form.data.index.v2=fs-forms-data-alias-v2
+get.v2.formbyid.path=forms/v2/getFormById
+
 
 #workallocation es config
 
@@ -609,6 +614,9 @@ org.type.field.name=sborgtype
 kafka.topics.org.user.bulk.transfer.event.group=user-bulk-transfer-group
 org.hierarchy.bulk.user.transfer.container.name=userbulktransfer
 kafka.topics.org.user.bulk.transfer.event=dev.org.user.bulk.transfer
+bp.assignment.ans.folder.name=bp-assignment
+bp.assignment.answer.file.upload.max-size-kb=5000
+bp.assignment.answer.file.upload.allowed-extensions=pdf,doc,docx
 org.hierarchy.identifier.regex.pattern=<([^>]+)>
 
 org.level.hierarchy.cache.key.ttl=14400


### PR DESCRIPTION
* 4.8.30 dev v1 (#534) (#535)

* KB-11739 | Implemented an API to upload answer files to a GCP contain… (#528)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

---------



* KB-10860 | updating validation for upload answer file to GCP for assignment (#530)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-10860 | updating validation for upload answer file to GCP for assignment

---------



* KB-11769 | implemented answer file read API for assignment with validation. (#531)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-11769 | implemented answer file read API for assignment with validation.

---------



---------




* BP Reports enhancement (#540) (#541)

* BP Reports enhancement

* KB-11165 :BP Enrolment Report Enhancement



* 4.8.29 dev v5 (#539)

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy (#533)

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy

1.Added a new end point /org/v3/ext/signup/search . 2.It will check the new table created for the children list - if it is available then it would fetch the children identifiers and get the details from org search API. 3.If the children list is empty it will fallback on the older approach. 4.WarehouseDataSourceConfig class is added for warehouse JPA setup.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy

1. Removed the WarehouseDatasource configuration.
2. Moved the code to new class files.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy

1. Fixed the code review comments.
2. Implemented Cache for 4hours.

* Replaced the hardcoded key with the configured key.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy (#536)

1. Updated the response structure to keep it uniform .
2. In case of the fall back approach it was returning all the details so restricted to orgName,ChannelName and orgID

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy. (#537)

1. In case of the fall back approach it was mapping the id to sbOrgId ,updated it.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy (#538)

1. While caching we were saving the other details - modified it

---------


# Conflicts:
#	src/main/java/org/sunbird/common/util/CbExtServerProperties.java

* Dockerfile updated

* Dockerfile updated

* Dockerfile updated

* Dockerfile updated

* Dockerfile updated

* BP Report enhancement  (#542)

* BP Reports enhancement

* KB-11165 :BP Enrolment Report Enhancement

* KB-11165 :BP Enrolment Report Enhancement

* KB-11165 :BP Enrolment Report Enhancement

---------