### PR TITLE
Auto-create level-one term for new org (#557)

### DIFF
--- a/src/main/java/org/sunbird/org/consumer/OrgHierarchyForNewOrgConsumer.java
+++ b/src/main/java/org/sunbird/org/consumer/OrgHierarchyForNewOrgConsumer.java
@@ -1,0 +1,218 @@
+package org.sunbird.org.consumer;
+
+import com.datastax.driver.core.utils.UUIDs;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.sunbird.common.service.OutboundRequestHandlerServiceImpl;
+import org.sunbird.common.util.CbExtServerProperties;
+import org.sunbird.common.util.Constants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class OrgHierarchyForNewOrgConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(OrgHierarchyForNewOrgConsumer.class);
+
+    @Value("${max.retry.term.creation.new.org}")
+    private String maxRetry;
+
+    @Value("${term.creation.new.org.retry.delay.ms}")
+    private String retryDelays;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CbExtServerProperties serverProperties;
+
+    @Autowired
+    private OutboundRequestHandlerServiceImpl outboundRequestHandler;
+
+    @KafkaListener(topics = "${kafka.topics.org.hierarchy.framework.new.org.event}", groupId = "${kafka.topics.org.hierarchy.framework.new.org.event.group}")
+    public void processOrgHierarchyCreationForNewOrg(ConsumerRecord<String, String> data) {
+        logger.info("processOrgHierarchyCreationForNewOrg::Received event for new org hierarchy creation.");
+        logger.debug("Kafka Message: {}", data.value());
+        if (StringUtils.isBlank(data.value())) {
+            logger.error("Empty Kafka message received.");
+            return;
+        }
+        CompletableFuture.runAsync(() -> {
+            try {
+                initiateOrgHierarchyCreationForNewOrg(data.value());
+            } catch (Exception e) {
+                logger.error("Error while creating hierarchy framework for new org", e);
+                logger.error("Payload causing failure: {}", data.value());
+            }
+        });
+    }
+
+    private void initiateOrgHierarchyCreationForNewOrg(String value) {
+        long startTime = System.currentTimeMillis();
+        logger.info("initiateOrgHierarchyCreationForNewOrg::OrgHierarchy framework creation started.");
+        try {
+            HashMap<String, String> inputData = objectMapper.readValue(
+                    value,
+                    new TypeReference<HashMap<String, String>>() {
+                    }
+            );
+            List<String> errors = validateReceivedKafkaMessage(inputData);
+            if (!errors.isEmpty()) {
+                logger.error("Kafka message validation failed: {}", errors);
+                return;
+            }
+            createTermAndPublishFrameworkHierarchy(inputData);
+        } catch (Exception e) {
+            logger.error("Error processing orgHierarchy creation", e);
+        }
+        logger.info("initiateOrgHierarchyCreationForNewOrg::OrgHierarchy framework creation completed in {} ms",
+                (System.currentTimeMillis() - startTime));
+    }
+
+    private List<String> validateReceivedKafkaMessage(Map<String, String> input) {
+        List<String> errors = new ArrayList<>();
+        if (StringUtils.isBlank(input.get(Constants.SB_ROOT_ORG_ID))) {
+            errors.add("sbRootOrgId missing");
+        }
+        if (StringUtils.isEmpty(input.get(Constants.ORG_NAME))) {
+            errors.add("orgName missing");
+        }
+        if (StringUtils.isEmpty(input.get(Constants.ORG_ID))) {
+            errors.add("orgId missing");
+        }
+        return errors;
+    }
+
+    public void createTermAndPublishFrameworkHierarchy(Map<String, String> input) {
+
+        String sbRootOrgId = input.get(Constants.SB_ROOT_ORG_ID);
+        String orgName = input.get(Constants.ORG_NAME);
+        String orgId = input.get(Constants.ORG_ID);
+
+        if (StringUtils.isBlank(sbRootOrgId) || StringUtils.isBlank(orgName) || StringUtils.isBlank(orgId)) {
+            logger.error("Invalid input for term creation: required fields missing. Payload={}", input);
+            return;
+        }
+
+        String frameworkId = sbRootOrgId + Constants.ORG_HIERARCHY_SUFFIX;
+        String category = getCategoryForTermCreation(frameworkId, 0);
+        if (StringUtils.isBlank(category)) {
+            logger.error("Category not available or framework read failed for frameworkId={}", frameworkId);
+            return;
+        }
+
+        // Build request body
+        Map<String, Object> term = new HashMap<>();
+        term.put(Constants.NAME, orgName);
+        term.put(Constants.DESCRIPTION, input.get(Constants.DESCRIPTION));
+        term.put(Constants.CODE, UUIDs.timeBased().toString());
+
+        Map<String, Object> additionalProps = new HashMap<>();
+        additionalProps.put(Constants.ORG_ID, orgId);
+        term.put(Constants.ADDITIONAL_PROPERTIES, additionalProps);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        Map<String, Object> request = new HashMap<>();
+        request.put(Constants.TERM, term);
+        requestBody.put(Constants.REQUEST, request);
+
+        String createUrl = serverProperties.getKmBaseHost()
+                + serverProperties.getKmFrameworkTermCreatePath()
+                + "?framework=" + frameworkId
+                + "&category=" + category;
+
+        logger.info("Creating framework term: orgId={}, framework={}", orgId, frameworkId);
+
+        Map<String, Object> response = null;
+        int attempt = 0;
+
+        while (attempt < Integer.parseInt(maxRetry)) {
+            attempt++;
+            try {
+                response = outboundRequestHandler.fetchResultUsingPost(createUrl, requestBody, null);
+                if (response != null && Constants.OK.equalsIgnoreCase(String.valueOf(response.get(Constants.RESPONSE_CODE)))) {
+                    logger.info("Term created successfully on attempt {} for framework {}", attempt, frameworkId);
+                    publishFramework(frameworkId, sbRootOrgId);
+                    return;
+                }
+                logger.warn("Term creation attempt {} failed. Response={}", attempt, response);
+            } catch (Exception ex) {
+                logger.error("Error on attempt {} while creating term for framework {}: {}",
+                        attempt, frameworkId, ex.getMessage());
+            }
+
+            if (attempt < Integer.parseInt(maxRetry)) {
+                try {
+                    Thread.sleep(Long.parseLong(retryDelays));
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+        logger.error("Failed to create term for framework {} after {} attempts. LastResponse={}",
+                frameworkId, maxRetry, response);
+    }
+
+    private void publishFramework(String frameworkId, String orgId) {
+        logger.info("Publishing framework with created latest term");
+        String publishUrl = serverProperties.getKmBaseHost()
+                + serverProperties.getKmFrameworkPublishPath()
+                + "/" + frameworkId;
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.CONTENT_TYPE, "application/json");
+        headers.put(Constants.X_CHANNEL_ID, orgId);
+        logger.info("Publishing framework {}", frameworkId);
+        Map<String, Object> response = outboundRequestHandler.fetchResultUsingPost(publishUrl, new HashMap<>(), headers);
+        if (MapUtils.isNotEmpty(response) && "OK".equalsIgnoreCase((String) response.get("responseCode"))) {
+            logger.info("Framework published successfully.");
+        } else {
+            logger.error("Failed to publish framework: {}", response);
+        }
+    }
+
+    private String getCategoryForTermCreation(String frameworkId, int index) {
+
+        String url = serverProperties.getKmBaseHost()
+                + serverProperties.getFrameworkReadEndpoint()
+                + "/" + frameworkId;
+
+        logger.info("Reading framework from: {}", url);
+        Map<String, Object> response;
+        try {
+            response = (Map<String, Object>) outboundRequestHandler.fetchResult(url);
+        } catch (Exception e) {
+            logger.error("Error fetching framework {}: {}", frameworkId, e.getMessage());
+            return null;
+        }
+        if (MapUtils.isEmpty(response) || MapUtils.isEmpty((Map) response.get(Constants.RESULT))) {
+            logger.error("Invalid framework response: {}", response);
+            return null;
+        }
+        Map<String, Object> result = (Map<String, Object>) response.get(Constants.RESULT);
+        Map<String, Object> framework = (Map<String, Object>) result.get(Constants.FRAMEWORK);
+        if (MapUtils.isEmpty(framework)) {
+            logger.error("Framework object missing for {}", frameworkId);
+            return null;
+        }
+        List<Map<String, Object>> categories = (List<Map<String, Object>>) framework.get(Constants.CATEGORIES);
+        if (CollectionUtils.isEmpty(categories) || index >= categories.size()) {
+            logger.error("No category found at index {} for framework {}", index, frameworkId);
+            return null;
+        }
+        return String.valueOf(categories.get(index).get(Constants.NAME));
+    }
+}

--- a/src/main/java/org/sunbird/org/service/ExtendedOrgServiceImpl.java
+++ b/src/main/java/org/sunbird/org/service/ExtendedOrgServiceImpl.java
@@ -12,6 +12,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,7 @@ import org.sunbird.common.service.OutboundRequestHandlerServiceImpl;
 import org.sunbird.common.util.CbExtServerProperties;
 import org.sunbird.common.util.Constants;
 import org.sunbird.common.util.ProjectUtil;
+import org.sunbird.consumer.KafkaProducer;
 import org.sunbird.org.model.OrgHierarchy;
 import org.sunbird.org.model.OrgHierarchyInfo;
 import org.sunbird.org.repository.OrgHierarchyRepository;
@@ -41,7 +43,13 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 	@Autowired
 	OrgHierarchyRepository orgRepository;
 
-	ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    KafkaProducer kafkaProducer;
+
+    @Value("${kafka.topics.org.hierarchy.framework.new.org.event}")
+    private String kafkaTopicCreateHierarchyFramework;
+
+    ObjectMapper objectMapper = new ObjectMapper();
 
 
     @SuppressWarnings("unchecked")
@@ -62,6 +70,7 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 			String channelName = null;
 			boolean dbUpdateRequired = false;
 			boolean orgCreatedWithNewChannel = false;
+            boolean isNewOrgCreated = false;
 
 			if (StringUtils.isEmpty(orgId)) {
 				// There is no org exist for given Channel. We can simply create the same in
@@ -76,6 +85,7 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 					return response;
 				}
 				dbUpdateRequired = true;
+                isNewOrgCreated = true;
 			} else {
 				// The channel already exist. We need to check OrgHierarchy table for duplicate.
 				if (Constants.STATE.equalsIgnoreCase(orgType)
@@ -198,6 +208,11 @@ public class ExtendedOrgServiceImpl implements ExtendedOrgService {
 				response.getResult().put(Constants.ORGANIZATION_ID, orgId);
 				response.getResult().put(Constants.RESPONSE, Constants.SUCCESS);
 			}
+            //Push Message to Kafka
+            if(isNewOrgCreated || orgCreatedWithNewChannel){
+                requestData.put(Constants.ORG_ID, orgId);
+                kafkaProducer.push(kafkaTopicCreateHierarchyFramework, requestData);
+            }
 		} catch (Exception e) {
 			logger.error("Failed to create user. Exception: ", e);
 			response.getParams().setErrmsg(e.getMessage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,7 +71,7 @@ es.host.list=localhost:9200
 es.username=
 es.password=
 
-#Sunbird Elastic Search
+#Sunbird Elasitc Search
 sb.es.host.list=localhost:9200
 sb.es.username=
 sb.es.password=
@@ -569,6 +569,9 @@ validation.message.duplicate-levels=Avoid selecting duplicate values across leve
 kafka.topics.org.hierarchy.bulk.upload.event=dev.org.hierarchy.bulk.upload
 kafka.topics.org.hierarchy.bulk.upload.event.group=orgHierarchyBulkUpload
 org.hierarchy.bulk.upload.container.name=
+
+kafka.topics.org.hierarchy.framework.new.org.event=dev.org.hierarchy.new.org
+kafka.topics.org.hierarchy.framework.new.org.event.group=orgHierarchyNewOrg
 
 org.hierarchy.master.framework=org_hierarchy
 knowledge.mv.service=http://knowledge-mw-service:5000/


### PR DESCRIPTION
* 4.8.30 dev v1 (#534) (#535)

* KB-11739 | Implemented an API to upload answer files to a GCP contain… (#528)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

---------



* KB-10860 | updating validation for upload answer file to GCP for assignment (#530)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-10860 | updating validation for upload answer file to GCP for assignment

---------



* KB-11769 | implemented answer file read API for assignment with validation. (#531)

* KB-11739 | Implemented an API to upload answer files to a GCP container for assignments in the blended program.

* KB-11739 | updated code with constants formate.

* KB-11739 | updated API end point as per the review comment.

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-10860 | updating validation for upload answer file to GCP for assignment

* KB-11769 | implemented answer file read API for assignment with validation.

---------



---------




* BP Reports enhancement

* KB-11165 :BP Enrolment Report Enhancement

* BP Reports enhancement (#540) (#541)

* BP Reports enhancement

* KB-11165 :BP Enrolment Report Enhancement



* 4.8.29 dev v5 (#539)

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy (#533)

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy

1.Added a new end point /org/v3/ext/signup/search . 2.It will check the new table created for the children list - if it is available then it would fetch the children identifiers and get the details from org search API. 3.If the children list is empty it will fallback on the older approach. 4.WarehouseDataSourceConfig class is added for warehouse JPA setup.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy

1. Removed the WarehouseDatasource configuration.
2. Moved the code to new class files.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy

1. Fixed the code review comments.
2. Implemented Cache for 4hours.

* Replaced the hardcoded key with the configured key.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy (#536)

1. Updated the response structure to keep it uniform .
2. In case of the fall back approach it was returning all the details so restricted to orgName,ChannelName and orgID

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy. (#537)

1. In case of the fall back approach it was mapping the id to sbOrgId ,updated it.

* KB-11836 | DEV | BE | Enablement for MDO Report via new hierarchy (#538)

1. While caching we were saving the other details - modified it

---------


# Conflicts:
#	src/main/java/org/sunbird/common/util/CbExtServerProperties.java

* Dockerfile updated

* Dockerfile updated

* Dockerfile updated

* Dockerfile updated

* Dockerfile updated

* KB-11165 :BP Enrolment Report Enhancement

* KB-11165 :BP Enrolment Report Enhancement

* Auto-create level-one term for new org

* Auto-create level-one term for new org

* Auto-create level-one term for new org

* Auto-create level-one term for new org

---------