### PR TITLE
Feat(user-insights): add UserInsights Redis cache layer in front of Postgres for /user/v2/insights

### DIFF
--- a/src/main/java/org/sunbird/cache/RedisCacheMgr.java
+++ b/src/main/java/org/sunbird/cache/RedisCacheMgr.java
@@ -32,6 +32,9 @@ public class RedisCacheMgr {
     private JedisPool jedisDataPopulationPool;
 
     @Autowired
+    private JedisPool jedisUserInsightsPool;
+
+    @Autowired
     CbExtServerProperties cbExtServerProperties;
 
     private CbExtLogger logger = new CbExtLogger(getClass().getName());
@@ -303,4 +306,50 @@ public class RedisCacheMgr {
             return false;
         }
     }
+
+    /**
+     * Serializes and stores an object in the dedicated UserInsights Redis instance under the given key.
+     *
+     * <p>Uses a raw key (no {@code CB_EXT_} prefix) because this is a purpose-specific Redis instance
+     * rather than the shared primary cache. The entry is set with an explicit TTL so stale user-level
+     * stats are automatically evicted without manual intervention.</p>
+     *
+     * @param key    the raw Redis key (e.g. {@code userInsights_{userId}})
+     * @param object the object to serialize and cache; must be Jackson-serializable
+     * @param ttl    time-to-live in seconds for the cached entry
+     * @param index  the Redis database index to select before writing
+     */
+    public void putCacheToUserInsightsRedis(String key, Object object, int ttl, int index) {
+        try (Jedis jedis = jedisUserInsightsPool.getResource()) {
+            jedis.select(index);
+            String data = objectMapper.writeValueAsString(object);
+            jedis.set(key, data);
+            jedis.expire(key, ttl);
+            logger.debug("[UserInsights Redis] Saved key: " + key);
+        } catch (Exception e) {
+            logger.error(e);
+        }
+    }
+
+    /**
+     * Retrieves a raw JSON string from the dedicated UserInsights Redis instance for the given key.
+     *
+     * <p>Selects the specified database index before reading, matching the index used during the write.
+     * Returns {@code null} on a cache miss or any connectivity failure — callers are expected to handle
+     * a {@code null} return as a signal to fall back to the primary data source (Postgres).</p>
+     *
+     * @param key   the raw Redis key to look up (e.g. {@code userInsights_{userId}})
+     * @param index the Redis database index to select before reading
+     * @return the cached JSON string, or {@code null} if not found or an error occurs
+     */
+    public String getCacheFromUserInsightsRedis(String key, int index) {
+        try (Jedis jedis = jedisUserInsightsPool.getResource()) {
+            jedis.select(index);
+            return jedis.get(key);
+        } catch (Exception e) {
+            logger.error(e);
+            return null;
+        }
+    }
+
 }

--- a/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
+++ b/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
@@ -1222,6 +1222,18 @@ public class CbExtServerProperties {
 	@Value("${profile.preference.value}")
 	private String profilePreferenceValue;
 
+	@Value("${redis.user.insights.host.name}")
+	private String redisUserInsightsHostName;
+
+	@Value("${redis.user.insights.port}")
+	private String redisUserInsightsPort;
+
+	@Value("${redis.user.insights.index}")
+	private int redisUserInsightsIndex;
+
+	@Value("${redis.user.insights.ttl}")
+	private int redisUserInsightsTtl;
+
 	public String getProfilePreferenceValue() {
 		return profilePreferenceValue;
 	}
@@ -4105,4 +4117,39 @@ public class CbExtServerProperties {
 	public int getPeerValidationReportInprogressRestrictionHours() { return peerValidationReportInprogressRestrictionHours; }
 
 	public void setPeerValidationReportInprogressRestrictionHours(int peerValidationReportInprogressRestrictionHours) { this.peerValidationReportInprogressRestrictionHours = peerValidationReportInprogressRestrictionHours; }
+
+
+	public String getRedisUserInsightsHostName() {
+		return redisUserInsightsHostName;
+	}
+
+	public void setRedisUserInsightsHostName(String redisUserInsightsHostName) {
+		this.redisUserInsightsHostName = redisUserInsightsHostName;
+	}
+
+	public String getRedisUserInsightsPort() {
+		return redisUserInsightsPort;
+	}
+
+	public void setRedisUserInsightsPort(String redisUserInsightsPort) {
+		this.redisUserInsightsPort = redisUserInsightsPort;
+	}
+
+
+	public int getRedisUserInsightsIndex() {
+		return redisUserInsightsIndex;
+	}
+
+	public void setRedisUserInsightsIndex(int redisUserInsightsIndex) {
+		this.redisUserInsightsIndex = redisUserInsightsIndex;
+	}
+
+
+	public int getRedisUserInsightsTtl() {
+		return redisUserInsightsTtl;
+	}
+
+	public void setRedisUserInsightsTtl(int redisUserInsightsTtl) {
+		this.redisUserInsightsTtl = redisUserInsightsTtl;
+	}
 }

--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1571,4 +1571,5 @@ public class Constants {
 	public static final String TOTAL_BADGES = "total_badges";
 	public static final String REPORT_STATUS_COMPLETED = "COMPLETED";
 	public static final long HOURS_TO_MILLISECONDS = 60L * 60L * 1000L;
+	public static final String USER_INSIGHTS_CACHE_KEY_PREFIX = "userInsights_";
 }

--- a/src/main/java/org/sunbird/core/config/RedisConfig.java
+++ b/src/main/java/org/sunbird/core/config/RedisConfig.java
@@ -31,6 +31,14 @@ public class RedisConfig {
 				Integer.parseInt(cbProperties.getRedisDataPort()));
 		return jedisPool;
 	}
+
+	@Bean
+	public JedisPool jedisUserInsightsPool() {
+		final JedisPoolConfig poolConfig = buildPoolConfig();
+		return new JedisPool(poolConfig, cbProperties.getRedisUserInsightsHostName(),
+				Integer.parseInt(cbProperties.getRedisUserInsightsPort()));
+	}
+
 	private JedisPoolConfig buildPoolConfig() {
 		final JedisPoolConfig poolConfig = new JedisPoolConfig();
 		poolConfig.setMaxIdle(128);

--- a/src/main/java/org/sunbird/insights/controller/service/InsightsServiceImpl.java
+++ b/src/main/java/org/sunbird/insights/controller/service/InsightsServiceImpl.java
@@ -95,6 +95,13 @@ public class InsightsServiceImpl implements InsightsService {
         return  keys;
     }
     private Map<String, Object> populateIfClapsExist(String userId) {
+        Map<String, Object> cached = getClapsFromUserInsightsRedis(userId);
+        if (MapUtils.isNotEmpty(cached)) {
+            LocalDate[] dates = populateDate();
+            cached.put(Constants.START_DATE, dates[0]);
+            cached.put(Constants.END_DATE, dates[1]);
+            return cached;
+        }
         Optional<LearnerStatsEntity> optionalStats = learnerStatsRepository.findById(userId);
         Map<String, Object> response = new HashMap<>();
         if (optionalStats.isPresent()) {
@@ -142,6 +149,7 @@ public class InsightsServiceImpl implements InsightsService {
             response.put(W2, w2);
             response.put(W3, w3);
             response.put(W4, w4);
+            redisCacheMgr.putCacheToUserInsightsRedis(Constants.USER_INSIGHTS_CACHE_KEY_PREFIX + userId, response, serverProperties.getRedisUserInsightsTtl(), serverProperties.getRedisUserInsightsIndex());
         }
         LocalDate[]  dates = populateDate();
 
@@ -564,6 +572,34 @@ public class InsightsServiceImpl implements InsightsService {
         }
         response.getResult().put(DATA, result);
         return response;
+    }
+
+    /**
+     * Attempts to fetch the user's weekly claps/stats from the dedicated UserInsights Redis cache.
+     *
+     * <p>The cached payload contains {@code userId}, {@code totalClaps}, and weekly breakdown fields
+     * ({@code W1}–{@code W4}) but intentionally excludes date fields, as those are always derived
+     * fresh from the current date to remain accurate across the TTL window.</p>
+     *
+     * <p>Returns an empty map on cache miss or any Redis connectivity failure, allowing the caller
+     * to fall back gracefully to the Postgres read path.</p>
+     *
+     * @param userId the authenticated user's ID used to construct the Redis cache key
+     * @return a populated map of clap stats on cache hit, or {@link Collections#emptyMap()} on miss/error
+     */
+    private Map<String, Object> getClapsFromUserInsightsRedis(String userId) {
+        try {
+            String cachedData = redisCacheMgr.getCacheFromUserInsightsRedis(Constants.USER_INSIGHTS_CACHE_KEY_PREFIX + userId, serverProperties.getRedisUserInsightsIndex());
+            if (StringUtils.isNotBlank(cachedData)) {
+                Map<String, Object> cached = mapper.readValue(cachedData, new TypeReference<Map<String, Object>>() {
+                });
+                log.debug("UserInsights Redis cache hit for userId: {}", userId);
+                return cached;
+            }
+        } catch (Exception e) {
+            log.warn("UserInsights Redis cache unavailable for userId: {}, falling back to Postgres", userId, e);
+        }
+        return Collections.emptyMap();
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -661,4 +661,9 @@ redis.badge.dashboard.index=12
 peer.validation.report.ttl.seconds=86400
 peer.validation.report.restriction.hours=24
 peer.validation.report.progress.restriction.hours=1
-user.basicProfile.cache.ttl=14400
+
+# User Insights Redis server
+redis.user.insights.host.name=127.0.0.1
+redis.user.insights.port=6379
+redis.user.insights.ttl=86400
+redis.user.insights.index=0


### PR DESCRIPTION

- New JedisPool bean (jedisUserInsightsPool) with externalized host/port/index/ttl properties
- Write-through cache on Postgres hit; cache-first read with graceful fallback -Removed the duplicate redis key user.basicProfile.cache.ttl