### PR TITLE
feat(redis/walloffame): add leaderboard caching and externalize Redis pool config

### DIFF
--- a/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
+++ b/src/main/java/org/sunbird/common/util/CbExtServerProperties.java
@@ -1234,6 +1234,42 @@ public class CbExtServerProperties {
 	@Value("${redis.user.insights.ttl}")
 	private int redisUserInsightsTtl;
 
+	@Value("${redis.user.insights.leaderboard.ttl}")
+	private int redisLeaderboardTtl;
+
+	@Value("${redis.user.insights.leaderboard.index}")
+	private int redisLeaderboardIndex;
+
+	@Value("${redis.pool.max.total}")
+	private int redisPoolMaxTotal;
+
+	@Value("${redis.pool.max.idle}")
+	private int redisPoolMaxIdle;
+
+	@Value("${redis.pool.min.idle}")
+	private int redisPoolMinIdle;
+
+	@Value("${redis.pool.test.on.borrow}")
+	private boolean redisPoolTestOnBorrow;
+
+	@Value("${redis.pool.test.on.return}")
+	private boolean redisPoolTestOnReturn;
+
+	@Value("${redis.pool.test.while.idle}")
+	private boolean redisPoolTestWhileIdle;
+
+	@Value("${redis.pool.min.evictable.idle.time.ms}")
+	private long redisPoolMinEvictableIdleTimeMs;
+
+	@Value("${redis.pool.time.between.eviction.runs.ms}")
+	private long redisPoolTimeBetweenEvictionRunsMs;
+
+	@Value("${redis.pool.num.tests.per.eviction.run}")
+	private int redisPoolNumTestsPerEvictionRun;
+
+	@Value("${redis.pool.block.when.exhausted}")
+	private boolean redisPoolBlockWhenExhausted;
+
 	public String getProfilePreferenceValue() {
 		return profilePreferenceValue;
 	}
@@ -4151,5 +4187,102 @@ public class CbExtServerProperties {
 
 	public void setRedisUserInsightsTtl(int redisUserInsightsTtl) {
 		this.redisUserInsightsTtl = redisUserInsightsTtl;
+	}
+
+
+	public int getRedisLeaderboardTtl() {
+		return redisLeaderboardTtl;
+	}
+
+	public void setRedisLeaderboardTtl(int redisLeaderboardTtl) {
+		this.redisLeaderboardTtl = redisLeaderboardTtl;
+	}
+
+	public int getRedisLeaderboardIndex() {
+		return redisLeaderboardIndex;
+	}
+
+	public void setRedisLeaderboardIndex(int redisLeaderboardIndex) {
+		this.redisLeaderboardIndex = redisLeaderboardIndex;
+	}
+
+	public int getRedisPoolMaxTotal() {
+		return redisPoolMaxTotal;
+	}
+
+	public void setRedisPoolMaxTotal(int v) {
+		this.redisPoolMaxTotal = v;
+	}
+
+	public int getRedisPoolMaxIdle() {
+		return redisPoolMaxIdle;
+	}
+
+	public void setRedisPoolMaxIdle(int v) {
+		this.redisPoolMaxIdle = v;
+	}
+
+	public int getRedisPoolMinIdle() {
+		return redisPoolMinIdle;
+	}
+
+	public void setRedisPoolMinIdle(int v) {
+		this.redisPoolMinIdle = v;
+	}
+
+	public boolean isRedisPoolTestOnBorrow() {
+		return redisPoolTestOnBorrow;
+	}
+
+	public void setRedisPoolTestOnBorrow(boolean v) {
+		this.redisPoolTestOnBorrow = v;
+	}
+
+	public boolean isRedisPoolTestOnReturn() {
+		return redisPoolTestOnReturn;
+	}
+
+	public void setRedisPoolTestOnReturn(boolean v) {
+		this.redisPoolTestOnReturn = v;
+	}
+
+	public boolean isRedisPoolTestWhileIdle() {
+		return redisPoolTestWhileIdle;
+	}
+
+	public void setRedisPoolTestWhileIdle(boolean v) {
+		this.redisPoolTestWhileIdle = v;
+	}
+
+	public long getRedisPoolMinEvictableIdleTimeMs() {
+		return redisPoolMinEvictableIdleTimeMs;
+	}
+
+	public void setRedisPoolMinEvictableIdleTimeMs(long v) {
+		this.redisPoolMinEvictableIdleTimeMs = v;
+	}
+
+	public long getRedisPoolTimeBetweenEvictionRunsMs() {
+		return redisPoolTimeBetweenEvictionRunsMs;
+	}
+
+	public void setRedisPoolTimeBetweenEvictionRunsMs(long v) {
+		this.redisPoolTimeBetweenEvictionRunsMs = v;
+	}
+
+	public int getRedisPoolNumTestsPerEvictionRun() {
+		return redisPoolNumTestsPerEvictionRun;
+	}
+
+	public void setRedisPoolNumTestsPerEvictionRun(int v) {
+		this.redisPoolNumTestsPerEvictionRun = v;
+	}
+
+	public boolean isRedisPoolBlockWhenExhausted() {
+		return redisPoolBlockWhenExhausted;
+	}
+
+	public void setRedisPoolBlockWhenExhausted(boolean v) {
+		this.redisPoolBlockWhenExhausted = v;
 	}
 }

--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1572,4 +1572,5 @@ public class Constants {
 	public static final String REPORT_STATUS_COMPLETED = "COMPLETED";
 	public static final long HOURS_TO_MILLISECONDS = 60L * 60L * 1000L;
 	public static final String USER_INSIGHTS_CACHE_KEY_PREFIX = "userInsights_";
+	public static final String LEARNER_LEADERBOARD_CACHE_KEY_PREFIX = "learnerLeaderboard_";
 }

--- a/src/main/java/org/sunbird/core/config/RedisConfig.java
+++ b/src/main/java/org/sunbird/core/config/RedisConfig.java
@@ -41,16 +41,16 @@ public class RedisConfig {
 
 	private JedisPoolConfig buildPoolConfig() {
 		final JedisPoolConfig poolConfig = new JedisPoolConfig();
-		poolConfig.setMaxIdle(128);
-		poolConfig.setMaxTotal(3000);
-		poolConfig.setMinIdle(100);
-		poolConfig.setTestOnBorrow(true);
-		poolConfig.setTestOnReturn(true);
-		poolConfig.setTestWhileIdle(true);
-		poolConfig.setMinEvictableIdleTimeMillis(120000);
-		poolConfig.setTimeBetweenEvictionRunsMillis(30000);
-		poolConfig.setNumTestsPerEvictionRun(3);
-		poolConfig.setBlockWhenExhausted(true);
+		poolConfig.setMaxIdle(cbProperties.getRedisPoolMaxIdle());
+		poolConfig.setMaxTotal(cbProperties.getRedisPoolMaxTotal());
+		poolConfig.setMinIdle(cbProperties.getRedisPoolMinIdle());
+		poolConfig.setTestOnBorrow(cbProperties.isRedisPoolTestOnBorrow());
+		poolConfig.setTestOnReturn(cbProperties.isRedisPoolTestOnReturn());
+		poolConfig.setTestWhileIdle(cbProperties.isRedisPoolTestWhileIdle());
+		poolConfig.setMinEvictableIdleTimeMillis(cbProperties.getRedisPoolMinEvictableIdleTimeMs());
+		poolConfig.setTimeBetweenEvictionRunsMillis(cbProperties.getRedisPoolTimeBetweenEvictionRunsMs());
+		poolConfig.setNumTestsPerEvictionRun(cbProperties.getRedisPoolNumTestsPerEvictionRun());
+		poolConfig.setBlockWhenExhausted(cbProperties.isRedisPoolBlockWhenExhausted());
 		return poolConfig;
 	}
 }

--- a/src/main/java/org/sunbird/walloffame/service/WallOfFameServiceImpl.java
+++ b/src/main/java/org/sunbird/walloffame/service/WallOfFameServiceImpl.java
@@ -102,13 +102,14 @@ public class WallOfFameServiceImpl implements WallOfFameService {
             }
             String cachedJson = redisCacheMgr.getCacheFromUserInsightsRedis(Constants.LEARNER_LEADERBOARD_CACHE_KEY_PREFIX + rootOrgId + "_" + userId, properties.getRedisLeaderboardIndex());
             if (StringUtils.isNotBlank(cachedJson)) {
+                logger.info("Cache hit for learner leaderboard for userId: {} and rootOrgId: {}", userId, rootOrgId);
                 List<Map<String, Object>> cached = objectMapper.readValue(cachedJson,
                         new TypeReference<List<Map<String, Object>>>() {});
                 response.put(Constants.RESULT, cached);
                 response.put(Constants.COUNT, cached.size());
                 return response;
             }
-
+            logger.info("Cache miss for learner leaderboard for userId: {} and rootOrgId: {}", userId, rootOrgId);
             Map<String, Object> propertiesMap = new HashMap<>();
             propertiesMap.put(Constants.USER_ID_LOWER, userId);
 

--- a/src/main/java/org/sunbird/walloffame/service/WallOfFameServiceImpl.java
+++ b/src/main/java/org/sunbird/walloffame/service/WallOfFameServiceImpl.java
@@ -14,9 +14,12 @@ import org.sunbird.common.util.AccessTokenValidator;
 import org.sunbird.common.util.CbExtServerProperties;
 import org.sunbird.common.util.Constants;
 import org.sunbird.common.util.ProjectUtil;
+import org.sunbird.cache.RedisCacheMgr;
 import org.sunbird.walloffame.entity.*;
 import org.sunbird.walloffame.repository.*;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -36,6 +39,12 @@ public class WallOfFameServiceImpl implements WallOfFameService {
 
     @Autowired
     CbExtServerProperties properties;
+
+    @Autowired
+    private RedisCacheMgr redisCacheMgr;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private UserLeaderboardRepository leaderboardRepository;
@@ -91,6 +100,14 @@ public class WallOfFameServiceImpl implements WallOfFameService {
                 setBadRequestResponse(response, Constants.USER_ID_DOESNT_EXIST);
                 return response;
             }
+            String cachedJson = redisCacheMgr.getCacheFromUserInsightsRedis(Constants.LEARNER_LEADERBOARD_CACHE_KEY_PREFIX + rootOrgId + "_" + userId, properties.getRedisLeaderboardIndex());
+            if (StringUtils.isNotBlank(cachedJson)) {
+                List<Map<String, Object>> cached = objectMapper.readValue(cachedJson,
+                        new TypeReference<List<Map<String, Object>>>() {});
+                response.put(Constants.RESULT, cached);
+                response.put(Constants.COUNT, cached.size());
+                return response;
+            }
 
             Map<String, Object> propertiesMap = new HashMap<>();
             propertiesMap.put(Constants.USER_ID_LOWER, userId);
@@ -123,6 +140,12 @@ public class WallOfFameServiceImpl implements WallOfFameService {
 
             response.put(Constants.RESULT, result);
             response.put(Constants.COUNT, result == null ? 0 : result.size());
+            if (!CollectionUtils.isEmpty(result)) {
+                redisCacheMgr.putCacheToUserInsightsRedis(Constants.LEARNER_LEADERBOARD_CACHE_KEY_PREFIX + rootOrgId + "_" + userId, result,
+                        properties.getRedisLeaderboardTtl(),
+                        properties.getRedisLeaderboardIndex());
+            }
+           
             return response;
 
         } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -667,3 +667,17 @@ redis.user.insights.host.name=127.0.0.1
 redis.user.insights.port=6379
 redis.user.insights.ttl=86400
 redis.user.insights.index=0
+redis.user.insights.leaderboard.ttl=3600
+redis.user.insights.leaderboard.index=2
+
+# Redis pool config
+redis.pool.max.total=3000
+redis.pool.max.idle=128
+redis.pool.min.idle=100
+redis.pool.test.on.borrow=true
+redis.pool.test.on.return=true
+redis.pool.test.while.idle=true
+redis.pool.min.evictable.idle.time.ms=120000
+redis.pool.time.between.eviction.runs.ms=30000
+redis.pool.num.tests.per.eviction.run=3
+redis.pool.block.when.exhausted=true


### PR DESCRIPTION
WallOfFameServiceImpl
- Inject RedisCacheMgr and ObjectMapper (@Autowired)
- Cache-aside read before Cassandra queries (early exit on hit)
- Cache write after DB fetch using leaderboard-specific TTL and index
- Key format: learnerLeaderboard_{rootOrgId}_{userId}

RedisConfig
- buildPoolConfig() now reads all values from CbExtServerProperties instead of hardcoded literals (max.total, max.idle, min.idle, test.*, eviction timing, block.when.exhausted)

Constants
- Added LEARNER_LEADERBOARD_CACHE_KEY_PREFIX

application.properties
- redis.user.insights.leaderboard.ttl=3600
- redis.user.insights.leaderboard.index=2
- redis.pool.* (10 pool tuning properties)