### PR TITLE
fix(insights): use Optional to eliminate null returns in cache lookup

### DIFF
--- a/src/main/java/org/sunbird/insights/controller/service/InsightsServiceImpl.java
+++ b/src/main/java/org/sunbird/insights/controller/service/InsightsServiceImpl.java
@@ -95,9 +95,10 @@ public class InsightsServiceImpl implements InsightsService {
         return  keys;
     }
     private Map<String, Object> populateIfClapsExist(String userId) {
-        Map<String, Object> cached = getClapsFromUserInsightsRedis(userId);
-        if (MapUtils.isNotEmpty(cached)) {
+        Optional<Map<String, Object>> cachedOpt = getClapsFromUserInsightsRedis(userId);
+        if (cachedOpt.isPresent()) {
             log.info("successfully fetching data from redis for weekly cap Insights");
+            Map<String, Object> cached = cachedOpt.get();
             LocalDate[] dates = populateDate();
             cached.put(Constants.START_DATE, dates[0]);
             cached.put(Constants.END_DATE, dates[1]);
@@ -151,14 +152,12 @@ public class InsightsServiceImpl implements InsightsService {
             response.put(W2, w2);
             response.put(W3, w3);
             response.put(W4, w4);
-            redisCacheMgr.putCacheToUserInsightsRedis(Constants.USER_INSIGHTS_CACHE_KEY_PREFIX + userId, response, serverProperties.getRedisUserInsightsTtl(), serverProperties.getRedisUserInsightsIndex());
         }
-        LocalDate[]  dates = populateDate();
-
-
-            response.put(Constants.START_DATE, dates[0]);
-            response.put(Constants.END_DATE, dates[1]);
-            return response;
+        redisCacheMgr.putCacheToUserInsightsRedis(Constants.USER_INSIGHTS_CACHE_KEY_PREFIX + userId, response, serverProperties.getRedisUserInsightsTtl(), serverProperties.getRedisUserInsightsIndex());
+        LocalDate[] dates = populateDate();
+        response.put(Constants.START_DATE, dates[0]);
+        response.put(Constants.END_DATE, dates[1]);
+        return response;
 
 
     }
@@ -587,21 +586,21 @@ public class InsightsServiceImpl implements InsightsService {
      * to fall back gracefully to the Postgres read path.</p>
      *
      * @param userId the authenticated user's ID used to construct the Redis cache key
-     * @return a populated map of clap stats on cache hit, or {@link Collections#emptyMap()} on miss/error
+     * @return an {@link Optional} containing the cached clap stats map on hit, or empty on miss/error
      */
-    private Map<String, Object> getClapsFromUserInsightsRedis(String userId) {
+    private Optional<Map<String, Object>> getClapsFromUserInsightsRedis(String userId) {
         try {
             String cachedData = redisCacheMgr.getCacheFromUserInsightsRedis(Constants.USER_INSIGHTS_CACHE_KEY_PREFIX + userId, serverProperties.getRedisUserInsightsIndex());
             if (StringUtils.isNotBlank(cachedData)) {
                 Map<String, Object> cached = mapper.readValue(cachedData, new TypeReference<Map<String, Object>>() {
                 });
                 log.debug("UserInsights Redis cache hit for userId: {}", userId);
-                return cached;
+                return Optional.of(cached);
             }
         } catch (Exception e) {
             log.warn("UserInsights Redis cache unavailable for userId: {}, falling back to Postgres", userId, e);
         }
-        return Collections.emptyMap();
+        return Optional.empty();
     }
 }
 


### PR DESCRIPTION
- Changed getClapsFromUserInsightsRedis() return type from Map to Optional<Map<String, Object>>, returning Optional.of() on hit and Optional.empty() on miss/error instead of null
- Updated populateIfClapsExist() to use cachedOpt.isPresent() / cachedOpt.get() instead of != null check
- Moved putCacheToUserInsightsRedis() outside the isPresent() block so empty Postgres results are also cached, preventing repeated DB calls for users with no learner_stats record