### PR TITLE
KB-14010 | Q12 | BE | Blended Program Enhancements | Batch-wise reports

### DIFF
--- a/src/main/java/org/sunbird/bpreports/service/BPReportsServiceV2Impl.java
+++ b/src/main/java/org/sunbird/bpreports/service/BPReportsServiceV2Impl.java
@@ -116,7 +116,7 @@ public class BPReportsServiceV2Impl implements BPReportsServiceV2 {
         Map<String, Map<String, String>> userInfoMap = new HashMap<>();
         userUtilityService.getUserDetailsFromDB(
                 Collections.singletonList(userId),
-                Collections.singletonList(Constants.ROOT_ORG_ID),
+                Arrays.asList(Constants.USER_ID,Constants.ROOT_ORG_ID),
                 userInfoMap);
         String userOrgId = userInfoMap.get(userId).get(Constants.ROOT_ORG_ID);
         if (StringUtils.isBlank(userOrgId) || !userOrgId.equals(orgId)) {
@@ -998,17 +998,17 @@ public class BPReportsServiceV2Impl implements BPReportsServiceV2 {
         int col = 0;
         // Batch-level columns (16)
         setCellValue(row, col++, batchDetails.get(Constants.BATCH_ID));
-        setCellValue(row, col++, batchDetails.get(Constants.BATCH_NAME));
+        setCellValue(row, col++, batchDetails.get(Constants.NAME));
         setCellValue(row, col++, batchDetails.get(Constants.COURSE_ID));
         setCellValue(row, col++, referenceData.get(Constants.PROGRAM_NAME));
         setCellValue(row, col++, referenceData.get(Constants.PRIMARY_CATEGORY));
         setCellValue(row, col++, referenceData.get(Constants.MDO_NAME));
         setCellValue(row, col++, referenceData.get(Constants.PROGRAM_COORDINATOR_NAME));
         setCellValue(row, col++, batchDetails.get(Constants.STATUS));
-        setCellValue(row, col++, batchDetails.get(Constants.START_DATE));
-        setCellValue(row, col++, batchDetails.get(Constants.END_DATE));
-        setCellValue(row, col++, batchDetails.get(Constants.REGISTRATION_START_DATE));
-        setCellValue(row, col++, batchDetails.get(Constants.REGISTRATION_END_DATE));
+        setCellValue(row, col++, batchDetails.get(Constants.START_DATE_COLUMN));
+        setCellValue(row, col++, batchDetails.get(Constants.END_DATE_COLUMN));
+        setCellValue(row, col++, batchDetails.get(Constants.START_DATE_COLUMN));
+        setCellValue(row, col++, batchDetails.get(Constants.ENROLMENT_END_DATE_COLUMN));
         setCellValue(row, col++, computeBatchDuration(batchDetails));
         setCellValue(row, col++, totalEnrolled);
         setCellValue(row, col++, batchDetails.get(Constants.CREATED_DATE));
@@ -1080,8 +1080,8 @@ public class BPReportsServiceV2Impl implements BPReportsServiceV2 {
      * or an empty string if either date is missing or unparseable.
      */
     private String computeBatchDuration(Map<String, Object> batchDetails) {
-        LocalDate start = parseToLocalDate(batchDetails.get(Constants.START_DATE));
-        LocalDate end = parseToLocalDate(batchDetails.get(Constants.END_DATE));
+        LocalDate start = parseToLocalDate(batchDetails.get(Constants.START_DATE_COLUMN));
+        LocalDate end = parseToLocalDate(batchDetails.get(Constants.END_DATE_COLUMN));
         if (Objects.nonNull(start) && Objects.nonNull(end)) {
             return String.valueOf(ChronoUnit.DAYS.between(start, end));
         }

--- a/src/main/java/org/sunbird/common/util/Constants.java
+++ b/src/main/java/org/sunbird/common/util/Constants.java
@@ -1603,4 +1603,5 @@ public class Constants {
 	public static final String CERTIFICATE_ISSUED = "certificateIssued";
 	public static final String CERTIFICATE_ISSUED_DATE = "certificateIssuedDate";
 	public static final String BP_REPORT_GENERATE_API_V2 ="api.generate.bp.report.v2";
+	public static final String ENROLMENT_END_DATE_COLUMN = "enrollment_enddate";
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -691,5 +691,5 @@ bp.report.cassandra.in.chunk.size=100
 bp.report.wf.page.size=100
 bp.report.sheet.name=Enrollment Report
 bp.report.excel.row.window.size=100
-bp.report.batch.detail.fields=batchId,courseId,batchName,status,startDate,endDate,registrationStartDate,registrationEndDate,createdBy,createdDate,createdFor,batch_attributes
+bp.report.batch.detail.fields=batchId,courseId,name,status,start_date,end_date,enrollment_enddate,createdBy,createdDate,createdFor,batch_attributes
 bp.report.v2.headers=Batch ID,Batch Name,Program ID,Program Name,Program Type,MDO / Department Name,Program Coordinator Name,Batch Status,Batch Start Date,Batch End Date,Enrollment Start Date,Enrollment End Date,Batch Duration (Days),Total Enrolled Learners,Batch Created Date,Batch Created By,Name,Organisation,Group,Designation,Employee ID,Email,Mobile Number,Gender,Date of Birth,Mother Tongue,Category,Office Pin Code,Are you a Cadre Employee,Type of Service,Service,Cadre,Cadre Batch,Cadre Controlling Authority Name,eHRMS ID / External System ID,Date of Retirement,Enrollment Status,Designation (filled during enrollment),Group (filled during enrollment),Learner Name,Email ID,Department / Ministry,Enrollment Date,Instructor Name,Certificate Issued (Y/N),Certificate Issued Date


### PR DESCRIPTION
fix: correct Cassandra column mappings in BP V2 report generation

Changes:
- bp.report.batch.detail.fields: replaced batchName → name, startDate → start_date, endDate → end_date, registrationEndDate → enrollment_enddate, and removed registrationStartDate (no such column exists in course_batch or the Sunbird batch API v1 model)
- writeDataRow: updated all four date reads and batch name read to use the corrected constants (START_DATE_COLUMN, END_DATE_COLUMN, ENROLMENT_END_DATE_COLUMN, NAME); Enrollment Start Date falls back to start_date since no dedicated enrollment start date column exists
- computeBatchDuration: updated to use START_DATE_COLUMN / END_DATE_COLUMN so duration calculation is no longer null
- Added constant ENROLMENT_END_DATE_COLUMN = "enrollment_enddate"